### PR TITLE
opae.io: flask server: add Grafana SimpleJson api

### DIFF
--- a/binaries/opae.io/opae/io/run.py
+++ b/binaries/opae.io/opae/io/run.py
@@ -1,5 +1,11 @@
 import json
-from flask import Flask, request, abort
+import os
+from pprint import pprint
+import subprocess
+import sys
+import tempfile
+import time
+from flask import Flask, request, abort, jsonify
 from opae import fpga
 
 DEFAULT_SRV_PORT = 8080
@@ -32,6 +38,68 @@ attrs = {
         'type': (fpga.DEVICE, fpga.ACCELERATOR),
         'vendor_id': (fpga.DEVICE, fpga.ACCELERATOR),
 }
+
+
+# For grafana SimpleJson data source
+
+def now_in_milliseconds():
+    return int(time.time()) * 1000
+
+
+def get_sensors_json():
+    tmpfile = tempfile.NamedTemporaryFile(mode='w+',
+        encoding=sys.getdefaultencoding(), newline='\n')
+    subprocess.run(['sensors', '-j'], stdout=tmpfile, stderr=subprocess.DEVNULL)
+    tmpfile.seek(0, os.SEEK_SET)
+    data = json.load(tmpfile)
+    tmpfile.close()
+    return data
+
+
+@app.route('/', methods=['GET', 'POST'])
+def test():
+    return 'OK'
+
+datapoints = {}
+
+@app.route('/search', methods=['GET', 'POST'])
+def search():
+    j = request.get_json()
+
+    result = []
+    for x in j['targets']:
+        target = x['target']
+        if target not in datapoints:
+            datapoints[target] = []
+        result.append(target)
+
+    return jsonify(result)
+
+
+@app.route('/query', methods=['GET', 'POST'])
+def query():
+    j = request.get_json()
+    s = get_sensors_json()
+    n = s['n3000bmc_hwmon-isa-0000']
+
+    result = []
+    for x in j['targets']:
+        target = x['target']
+        if target not in datapoints:
+            datapoints[target] = []
+
+        value = 0.0
+        for k in n[target].keys():
+            if '_input' in k:
+                value = n[target][k]
+                break
+
+        datapoints[target].append([value, now_in_milliseconds()])
+        result.append({'target': target, 'datapoints': datapoints[target] })
+
+    return jsonify(result)
+
+# End grafana SimpleJson data source
 
 
 def token_info(t: fpga.token):


### PR DESCRIPTION
Add a hacky, yet functional back-end implementation for the Grafana
SimpleJson plugin, to track the N3000 sensors using sensors -j.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>