### PR TITLE
ci: update python versions

### DIFF
--- a/.github/workflows/no-python-analysis.yml
+++ b/.github/workflows/no-python-analysis.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
     - run: exit 0

--- a/.github/workflows/pacsign.yml
+++ b/.github/workflows/pacsign.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-static-analysis.yml
+++ b/.github/workflows/python-static-analysis.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10, 3.11]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-static-analysis.yml
+++ b/.github/workflows/python-static-analysis.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10, 3.11]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
  - Remove Python 3.6, 3.7  and add 3.10,3.11 to versions to use for static analysis.

Signed-off-by: lab <ananda.ravuri@intel.com>