### PR TITLE
C++ style: don't change code in the working tree

### DIFF
--- a/scripts/test-codingstyle-all.sh
+++ b/scripts/test-codingstyle-all.sh
@@ -67,9 +67,9 @@ check_cpp () {
 
     FILES=$(find_cpp)
     echo "Checking $FILES"
-    clang-format -i -style=Google ${FILES}
+    clang-format --dry-run -Werror -style=Google ${FILES}
 
-    if [ x"$(git diff -- ${FILES})" != x ]; then
+    if [ $? -ne 0 ]; then
         echo "Coding style check failed. Please fix them based on the following suggestions. You can run clang-format on these files in order to automatically format your code." 
         git --no-pager diff
         echo "The files that need to be fixed are:"


### PR DESCRIPTION
Use --dry-run so that no code is changed, -Werror so that the process exit code is non-zero when a style violation is detected. Check the process exit code to determine pass/fail.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>