### PR TITLE
fix fedora spec file, remove ofs.uio from rhel spec file

### DIFF
--- a/binaries/ofs.uio/setup.py
+++ b/binaries/ofs.uio/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup, find_namespace_packages
 setup(
     name='ofs.uio',
     version="1.0",
-    packages=find_namespace_packages(include=['*']),
+    packages=find_namespace_packages(include=['uio*']),
     entry_points={
         'console_scripts': [
             'ofs.uio = uio.ofs_uio:main',

--- a/opae.spec.fedora
+++ b/opae.spec.fedora
@@ -221,7 +221,7 @@ for file in %{buildroot}%{python3_sitelib}/packager/tools/{afu_json_mgr,packager
 done
 
 # opae.uio
-for file in %{buildroot}%{python3_sitelib}/ofs.uio/uio/{ofs.uio}.py; do
+for file in %{buildroot}%{python3_sitelib}/uio/ofs_uio.py; do
    chmod a+x $file
 done
 
@@ -393,8 +393,8 @@ done
 %{python3_sitearch}/opae.io*
 %{python3_sitearch}/opae/io*
 %{python3_sitearch}/pyopaeuio*
-%{python3_sitearch}/ofs.uio*
-%{python3_sitearch}/ofs.uio/uio*
+%{python3_sitelib}/ofs.uio*
+%{python3_sitelib}/uio*
 
 
 %changelog

--- a/opae.spec.rhel
+++ b/opae.spec.rhel
@@ -116,7 +116,6 @@ mkdir -p %{buildroot}%{_usr}/src/opae/samples/host_exerciser
 mkdir -p %{buildroot}%{_usr}/src/opae/samples/hssi
 mkdir -p %{buildroot}%{_usr}/src/opae/samples/opae.io/opae/io
 mkdir -p %{buildroot}%{_usr}/src/opae/samples/opae.io/scripts
-mkdir -p %{buildroot}%{_usr}/src/opae/samples/ofs.uio/uio
 
 cp libraries/afu-test/*.{cpp,h} %{buildroot}%{_usr}/src/opae/samples/afu-test/
 cp samples/hello_fpga/hello_fpga.c %{buildroot}%{_usr}/src/opae/samples/hello_fpga/
@@ -129,7 +128,6 @@ cp samples/hssi/*.{cpp,h} %{buildroot}%{_usr}/src/opae/samples/hssi/
 cp binaries/opae.io/*.{cpp,h,py} %{buildroot}%{_usr}/src/opae/samples/opae.io/
 cp binaries/opae.io/opae/io/*.py %{buildroot}%{_usr}/src/opae/samples/opae.io/opae/io
 cp binaries/opae.io/scripts/*.py %{buildroot}%{_usr}/src/opae/samples/opae.io/scripts
-cp binaries/ofs.uio/uio/*.py %{buildroot}%{_usr}/src/opae/samples/ofs.uio/uio
 
 %if 0%{rhel} > 8
   %cmake_install
@@ -159,10 +157,7 @@ done
 for file in %{buildroot}%{python3_sitelib}/ethernet/{hssicommon,hssiloopback,hssimac,hssistats}.py; do
    chmod a+x $file
 done
-# ofs.uio
-for file in %{buildroot}%{python3_sitelib}/ofs.uio/uio/{ofs.uio}.py; do
-   chmod a+x $file
-done
+
 
 %files
 %dir %{_datadir}/opae
@@ -269,8 +264,6 @@ done
 %{_usr}/src/opae/samples/opae.io/scripts/nlb_walk.py
 %{_usr}/src/opae/samples/opae.io/scripts/port.py
 %{_usr}/src/opae/samples/opae.io/scripts/walk.py
-%{_usr}/src/opae/samples/ofs.uio/uio/__init__.py
-%{_usr}/src/opae/samples/ofs.uio/uio/ofs.uio.py
 
 
 %{_libdir}/libfpgad-api.so
@@ -323,14 +316,12 @@ done
 %{_bindir}/nlb3
 %{_bindir}/nlb7
 %{_bindir}/vabtool
-%{_bindir}/ofs.uio
 
 %{_usr}/share/opae/*
 %{python3_sitelib}/ethernet*
 %{python3_sitelib}/hssi_ethernet*
 %{python3_sitelib}/pacsign*
 %{python3_sitelib}/packager*
-%{python3_sitelib}/ofs.uio*
 
 
 %changelog


### PR DESCRIPTION
 - fix fedora spec file
 - remove ofs.uio from rhel spec file
   because of rhel doesn't   support pyopeauio

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>