### PR TITLE
cmake: gtest .so and include paths fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -510,13 +510,18 @@ if (OPAE_BUILD_TESTS)
     if (NOT GTest_FOUND)
         set(GTEST_ROOT ${FETCHCONTENT_BASE_DIR}/gtest-src CACHE PATH "gtest root directory" FORCE)
 
+        set(BUILD_SHARED_LIBS_ORIG ${BUILD_SHARED_LIBS})
+        set(BUILD_SHARED_LIBS ON)
+
         FetchContent_MakeAvailable(gtest)
 
+        set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_ORIG})
+
         set(GTEST_INCLUDE_DIR ${GTEST_ROOT}/googletest/include CACHE PATH "gtest include directory" FORCE)
-        set(GTEST_LIBRARY ${LIBRARY_OUTPUT_PATH}/libgtest.a CACHE PATH "path to gtest library" FORCE)
-        set(GTEST_MAIN_LIBRARY ${LIBRARY_OUTPUT_PATH}/libgtest_main.a CACHE PATH "path to gtest main library" FORCE)
-        set(GTEST_LIBRARY_DEBUG ${LIBRARY_OUTPUT_PATH}/libgtestd.a CACHE PATH "path to (debug) gtest library" FORCE)
-        set(GTEST_MAIN_LIBRARY_DEBUG ${LIBRARY_OUTPUT_PATH}/libgtest_maind.a CACHE PATH "path to (debug) gtest main library" FORCE)
+        set(GTEST_LIBRARY ${LIBRARY_OUTPUT_PATH}/libgtest.so CACHE PATH "path to gtest library" FORCE)
+        set(GTEST_MAIN_LIBRARY ${LIBRARY_OUTPUT_PATH}/libgtest_main.so CACHE PATH "path to gtest main library" FORCE)
+        set(GTEST_LIBRARY_DEBUG ${LIBRARY_OUTPUT_PATH}/libgtestd.so CACHE PATH "path to (debug) gtest library" FORCE)
+        set(GTEST_MAIN_LIBRARY_DEBUG ${LIBRARY_OUTPUT_PATH}/libgtest_maind.so CACHE PATH "path to (debug) gtest main library" FORCE)
         set(GTest_FOUND TRUE CACHE BOOL "GTest found by FetchContent" FORCE)
     endif(NOT GTest_FOUND)
 

--- a/cmake/modules/OPAETest.cmake
+++ b/cmake/modules/OPAETest.cmake
@@ -125,9 +125,11 @@ function(opae_test_add_static_lib)
             $<INSTALL_INTERFACE:include>
         PRIVATE
             ${OPAE_LIB_SOURCE}
-	    ${OPAE_LIB_SOURCE}/plugins/xfpga
-	    ${OPAE_LIB_SOURCE}/libopae-c
+            ${OPAE_LIB_SOURCE}/plugins/xfpga
+            ${OPAE_LIB_SOURCE}/libopae-c
             ${opae-test_ROOT}/framework
+            $<BUILD_INTERFACE:${json-c_INCLUDE_DIRS}>
+            $<BUILD_INTERFACE:${uuid_INCLUDE_DIRS}>
     )
 
     set_property(TARGET ${OPAE_TEST_ADD_STATIC_LIB_TARGET}

--- a/tests/opae-c/CMakeLists.txt
+++ b/tests/opae-c/CMakeLists.txt
@@ -185,8 +185,10 @@ add_library(dummy_plugin MODULE dummy_plugin.c)
 target_include_directories(dummy_plugin
     PRIVATE
         ${OPAE_INCLUDE_PATH}
-	${OPAE_LIB_SOURCE}/libopae-c
+        ${OPAE_LIB_SOURCE}/libopae-c
         ${opae-test_ROOT}/framework
+        ${json-c_INCLUDE_DIRS}
+        ${uuid_INCLUDE_DIRS}
 )
 
 target_link_libraries(dummy_plugin ${json-c_LIBRARIES})


### PR DESCRIPTION
* Force the gtest build to produce shared objects.
* Add include paths for static test libs and for dummy_plugin.so.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>