### PR TITLE
fix rpmlint non-executable-script errors

### DIFF
--- a/opae.spec.fedora
+++ b/opae.spec.fedora
@@ -116,29 +116,6 @@ cp LICENSE %{buildroot}%{_datadir}/opae/LICENSE
 cp COPYING %{buildroot}%{_datadir}/opae/COPYING
 
 mkdir -p %{buildroot}%{_usr}/src/opae/cmake/modules
-for s in \
-    FindCLI11.cmake \
-    FindCap.cmake \
-    Findhwloc.cmake \
-    FindSphinx.cmake \
-    Findtbb.cmake \
-    Finduuid.cmake \
-    FindUdev.cmake \
-    Findlibedit.cmake \
-    Findjson-c.cmake \
-    Findspdlog.cmake \
-    OFS.cmake \
-    OPAE.cmake \
-    OPAECompiler.cmake \
-    OPAEGit.cmake \
-    OPAEPlugin.cmake \
-    OPAEPackaging.cmake \
-    OPAETest.cmake
-do
-  cp "cmake/modules/${s}" %{buildroot}%{_usr}/src/opae/cmake/modules
-  chmod a+x %{buildroot}%{_usr}/src/opae/cmake/modules/$s
-done
-
 mkdir -p %{buildroot}%{_usr}/src/opae/samples
 mkdir -p %{buildroot}%{_usr}/src/opae/samples/hello_fpga/
 mkdir -p %{buildroot}%{_usr}/src/opae/samples/hello_events/
@@ -163,6 +140,15 @@ cp samples/n5010-test/n5010-test.c %{buildroot}%{_usr}/src/opae/samples/n5010-te
   echo "Installing for non-RHEL"
   %cmake_install
 %endif
+
+#cmake
+for file in %{buildroot}%{_usr}/lib/opae*/modules/*; do
+   chmod a+x $file
+done
+
+for file in %{buildroot}%{_usr}/src/opae/cmake/modules/*; do
+   chmod a+x $file
+done
 
 prev=$PWD
 pushd %{_topdir}/BUILD/%{name}-%{version}-%{opae_release}/binaries/opae.io

--- a/opae.spec.rhel
+++ b/opae.spec.rhel
@@ -83,29 +83,6 @@ cp LICENSE %{buildroot}%{_datadir}/opae/LICENSE
 cp COPYING %{buildroot}%{_datadir}/opae/COPYING
 
 mkdir -p %{buildroot}%{_usr}/src/opae/cmake/modules
-for s in \
-    FindCLI11.cmake \
-    FindCap.cmake \
-    Findhwloc.cmake \
-    FindSphinx.cmake \
-    Findtbb.cmake \
-    Finduuid.cmake \
-    FindUdev.cmake \
-    Findlibedit.cmake \
-    Findjson-c.cmake \
-    Findspdlog.cmake \
-    OFS.cmake \
-    OPAE.cmake \
-    OPAECompiler.cmake \
-    OPAEGit.cmake \
-    OPAEPlugin.cmake \
-    OPAEPackaging.cmake \
-    OPAETest.cmake
-do
-  cp "cmake/modules/${s}" %{buildroot}%{_usr}/src/opae/cmake/modules
-  chmod a+x %{buildroot}%{_usr}/src/opae/cmake/modules/$s
-done
-
 mkdir -p %{buildroot}%{_usr}/src/opae/samples
 mkdir -p %{buildroot}%{_usr}/src/opae/samples/afu-test
 mkdir -p %{buildroot}%{_usr}/src/opae/samples/hello_fpga
@@ -136,6 +113,15 @@ cp binaries/opae.io/scripts/*.py %{buildroot}%{_usr}/src/opae/samples/opae.io/sc
   %make_install
 %endif
 
+#cmake
+for file in %{buildroot}%{_usr}/lib/opae*/modules/*; do
+   chmod a+x $file
+done
+
+for file in %{buildroot}%{_usr}/src/opae/cmake/modules/*; do
+   chmod a+x $file
+done
+
 prev=$PWD
 pushd %{_topdir}/BUILD/%{name}-%{version}-%{opae_release}/python/opae.admin/
 %{__python3} setup.py install --single-version-externally-managed  --root=%{buildroot} 
@@ -159,6 +145,10 @@ for file in %{buildroot}%{python3_sitelib}/ethernet/{hssicommon,hssiloopback,hss
    chmod a+x $file
 done
 
+# packager
+for file in %{buildroot}%{python3_sitelib}/packager/tools/{afu_json_mgr,packager}.py; do
+   chmod a+x $file
+done
 
 %files
 %dir %{_datadir}/opae


### PR DESCRIPTION
Error: opae-devel.x86_64: E: non-executable-script /usr/lib/opae-2.2.0/modules/OPAEGit.cmake 644 /usr/bin/cmake -P Add execute permissions to  .cmake

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>