### PR TITLE
libofs: correct unit test failures

### DIFF
--- a/include/ofs/ofs_primitives.h
+++ b/include/ofs/ofs_primitives.h
@@ -49,10 +49,12 @@
 ({                                                                          \
 	int _status = 0;                                                    \
 	OFS_TIMESPEC_USEC(ts, _sleep_usec);                                 \
-	struct timespec begin, now, rem;                                    \
+	struct timespec begin, now, save, rem;                              \
+	save = ts;                                                          \
 	clock_gettime(CLOCK_MONOTONIC, &begin);                             \
 	while(_bit != _value) {                                             \
 		if (_sleep_usec) {                                          \
+			ts = save;                                          \
 			while ((nanosleep(&ts, &rem) == -1) &&              \
 			       (errno == EINTR))                            \
 				ts = rem;                                   \
@@ -66,17 +68,19 @@
 			break;                                              \
 		}                                                           \
 	}                                                                   \
-        _status;                                                            \
+	_status;                                                            \
 })                                                                          \
 
 #define OFS_WAIT_FOR_NE(_bit, _value, _timeout_usec, _sleep_usec)           \
 ({                                                                          \
 	int _status = 0;                                                    \
 	OFS_TIMESPEC_USEC(ts, _sleep_usec);                                 \
-	struct timespec begin, now, rem;                                    \
+	struct timespec begin, now, save, rem;                              \
+	save = ts;                                                          \
 	clock_gettime(CLOCK_MONOTONIC, &begin);                             \
 	while(_bit == _value) {                                             \
 		if (_sleep_usec) {                                          \
+			ts = save;                                          \
 			while ((nanosleep(&ts, &rem) == -1) &&              \
 			       (errno == EINTR))                            \
 				ts = rem;                                   \
@@ -90,7 +94,7 @@
 			break;                                              \
 		}                                                           \
 	}                                                                   \
-        _status;                                                            \
+	_status;                                                            \
 })                                                                          \
 
 #ifdef __cplusplus
@@ -155,10 +159,12 @@ inline int ofs_wait_for_eq32(volatile uint32_t *var, uint32_t value,
 			     uint64_t timeout_usec, uint32_t sleep_usec)
 {
 	OFS_TIMESPEC_USEC(ts, sleep_usec);
-	struct timespec begin, now, rem;
+	struct timespec begin, now, save, rem;
+	save = ts;
 	clock_gettime(CLOCK_MONOTONIC, &begin);
 	while(*var != value) {
 		if (sleep_usec) {
+			ts = save;
 			while((nanosleep(&ts, &rem) == -1) &&
 			      (errno == EINTR))
 				ts = rem;
@@ -191,10 +197,12 @@ inline int ofs_wait_for_eq64(volatile uint64_t *var, uint64_t value,
 			     uint64_t timeout_usec, uint32_t sleep_usec)
 {
 	OFS_TIMESPEC_USEC(ts, sleep_usec);
-	struct timespec begin, now, rem;
+	struct timespec begin, now, save, rem;
+	save = ts;
 	clock_gettime(CLOCK_MONOTONIC, &begin);
 	while(*var != value) {
 		if (sleep_usec) {
+			ts = save;
 			while ((nanosleep(&ts, &rem) == -1) &&
 			       (errno == EINTR))
 				ts = rem;

--- a/include/ofs/ofs_primitives.h
+++ b/include/ofs/ofs_primitives.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2021, Intel Corporation
+// Copyright(c) 2021-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -27,6 +27,7 @@
 #define OFS_PRIMITIVES_H
 
 #include <stdint.h>
+#include <errno.h>
 #include <time.h>
 
 #define SEC2NSEC 1000000000
@@ -48,11 +49,14 @@
 ({                                                                          \
 	int _status = 0;                                                    \
 	OFS_TIMESPEC_USEC(ts, _sleep_usec);                                 \
-	struct timespec begin, now;                                         \
+	struct timespec begin, now, rem;                                    \
 	clock_gettime(CLOCK_MONOTONIC, &begin);                             \
 	while(_bit != _value) {                                             \
-		if (_sleep_usec)                                            \
-			nanosleep(&ts, NULL);                               \
+		if (_sleep_usec) {                                          \
+			while ((nanosleep(&ts, &rem) == -1) &&              \
+			       (errno == EINTR))                            \
+				ts = rem;                                   \
+		}                                                           \
 		clock_gettime(CLOCK_MONOTONIC, &now);                       \
 		struct timespec delta;                                      \
 		ofs_diff_timespec(&delta, &now, &begin);                    \
@@ -69,11 +73,14 @@
 ({                                                                          \
 	int _status = 0;                                                    \
 	OFS_TIMESPEC_USEC(ts, _sleep_usec);                                 \
-	struct timespec begin, now;                                         \
+	struct timespec begin, now, rem;                                    \
 	clock_gettime(CLOCK_MONOTONIC, &begin);                             \
 	while(_bit == _value) {                                             \
-		if (_sleep_usec)                                            \
-			nanosleep(&ts, NULL);                               \
+		if (_sleep_usec) {                                          \
+			while ((nanosleep(&ts, &rem) == -1) &&              \
+			       (errno == EINTR))                            \
+				ts = rem;                                   \
+		}                                                           \
 		clock_gettime(CLOCK_MONOTONIC, &now);                       \
 		struct timespec delta;                                      \
 		ofs_diff_timespec(&delta, &now, &begin);                    \
@@ -144,15 +151,18 @@ inline int ofs_diff_timespec(struct timespec *result,
  *  @param[in] sleep_usec   Time (in usec) to sleep while waiting
  *  @returns 0 if variable changed to value while waiting, 1 otherwise
  */
-inline int ofs_wait_for_eq32(uint32_t *var, uint32_t value,
+inline int ofs_wait_for_eq32(volatile uint32_t *var, uint32_t value,
 			     uint64_t timeout_usec, uint32_t sleep_usec)
 {
 	OFS_TIMESPEC_USEC(ts, sleep_usec);
-	struct timespec begin, now;
+	struct timespec begin, now, rem;
 	clock_gettime(CLOCK_MONOTONIC, &begin);
 	while(*var != value) {
-		if (sleep_usec)
-			nanosleep(&ts, NULL);
+		if (sleep_usec) {
+			while((nanosleep(&ts, &rem) == -1) &&
+			      (errno == EINTR))
+				ts = rem;
+		}
 		clock_gettime(CLOCK_MONOTONIC, &now);
 		struct timespec delta;
 		ofs_diff_timespec(&delta, &now, &begin);
@@ -177,15 +187,18 @@ inline int ofs_wait_for_eq32(uint32_t *var, uint32_t value,
  *  @param[in] sleep_usec   Time (in usec) to sleep while waiting
  *  @returns 0 if variable changed to value while waiting, 1 otherwise
  */
-inline int ofs_wait_for_eq64(uint64_t *var, uint64_t value,
+inline int ofs_wait_for_eq64(volatile uint64_t *var, uint64_t value,
 			     uint64_t timeout_usec, uint32_t sleep_usec)
 {
 	OFS_TIMESPEC_USEC(ts, sleep_usec);
-	struct timespec begin, now;
+	struct timespec begin, now, rem;
 	clock_gettime(CLOCK_MONOTONIC, &begin);
 	while(*var != value) {
-		if (sleep_usec)
-			nanosleep(&ts, NULL);
+		if (sleep_usec) {
+			while ((nanosleep(&ts, &rem) == -1) &&
+			       (errno == EINTR))
+				ts = rem;
+		}
 		clock_gettime(CLOCK_MONOTONIC, &now);
 		struct timespec delta;
 		ofs_diff_timespec(&delta, &now, &begin);


### PR DESCRIPTION
From time to time, CI has been failing with one of these two error signatures:

libofs.wait_for_eq
/home/runner/work/opae-sdk/opae-sdk/tests/libofs/test_libofs.cpp:105: Failure Expected equality of these values:
  status
    Which is: 1
  0
/home/runner/work/opae-sdk/opae-sdk/tests/libofs/test_libofs.cpp:136: Failure Expected: (delta_usec) < (timeout_usec), actual: 1508 vs 1500

[ RUN      ] libofs.wait_for_eq
/home/tswhison/persist/opae-sdk/tests/libofs/test_libofs.cpp:105: Failure
Expected equality of these values:
  status
    Which is: 1
  0
/home/tswhison/persist/opae-sdk/tests/libofs/test_libofs.cpp:132: Failure
Expected: (delta_usec) < (timeout_usec), actual: 2104 vs 1500

These failures were reproduced using --gtest_shuffle and --gtest_repeat. The failures occurred on the order of 1 in 1000 test runs.

After experimenting with the changes in this commit, the failure rate was observed to decrease to 0 in 50,000 iterations.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>