### PR TITLE
build: re-enable parallel builds

### DIFF
--- a/.github/workflows/ccpp-tests.yml
+++ b/.github/workflows/ccpp-tests.yml
@@ -69,7 +69,7 @@ jobs:
     - name: configure ${{ matrix.build-type }}
       run: mkdir ${{ github.workspace }}/.build && cd ${{ github.workspace }}/.build && cmake .. -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
     - name: make ${{ matrix.build-type }}
-      run: cd ${{ github.workspace }}/.build && make -j
+      run: cd ${{ github.workspace }}/.build && make -j $(nproc)
   test:
     runs-on: ubuntu-latest
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,9 +114,19 @@ if (NOT uuid_FOUND)
         BUILD_IN_SOURCE ON
     )
 
-    add_custom_target(uuid_symlink ALL
-        ln -sf ${CMAKE_CURRENT_BINARY_DIR}/uuid-prefix/src/uuid/libuuid/src ${CMAKE_CURRENT_BINARY_DIR}/uuid-prefix/src/uuid/libuuid/uuid
-        COMMENT "Creating include symlink for uuid")
+    add_custom_command(
+        OUTPUT
+            ${CMAKE_CURRENT_BINARY_DIR}/uuid-prefix/src/uuid/libuuid/uuid
+        COMMAND
+            ln -sf ${CMAKE_CURRENT_BINARY_DIR}/uuid-prefix/src/uuid/libuuid/src ${CMAKE_CURRENT_BINARY_DIR}/uuid-prefix/src/uuid/libuuid/uuid
+        DEPENDS
+            ${CMAKE_CURRENT_BINARY_DIR}/uuid-prefix/src/uuid/libuuid/src
+    )
+
+    add_custom_target(uuid_symlink
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/uuid-prefix/src/uuid/libuuid/uuid
+        COMMENT "Creating include symlink for uuid"
+    )
     add_dependencies(uuid_symlink uuid)
 
     set(uuid_ROOT ${CMAKE_CURRENT_BINARY_DIR}/uuid-prefix/src/uuid/libuuid CACHE PATH "base dir for uuid" FORCE)
@@ -127,6 +137,20 @@ if (NOT uuid_FOUND)
         CACHE STRING "Path to uuid libraries" FORCE)
     set(uuid_DEFINITIONS "" CACHE STRING "uuid built from source" FORCE)
     set(uuid_FOUND TRUE CACHE BOOL "uuid built from source" FORCE)
+
+    add_library(uuid_IMPORT SHARED IMPORTED)
+    target_include_directories(uuid_IMPORT
+        INTERFACE
+            ${uuid_INCLUDE_DIRS}
+    )
+    set_property(
+        TARGET uuid_IMPORT
+        PROPERTY
+            IMPORTED_LOCATION "${uuid_LIBRARIES}"
+    )
+    add_dependencies(uuid_IMPORT uuid_symlink)
+    set(uuid_IMPORTED TRUE CACHE BOOL "uuid imported from source" FORCE)
+
 endif(NOT uuid_FOUND)
 
 message(STATUS "uuid_ROOT ${uuid_ROOT}")
@@ -159,15 +183,55 @@ if (NOT json-c_FOUND)
 
     FetchContent_MakeAvailable(json-c)
 
-    add_custom_target(json-c_symlink ALL
-        ln -sf ${FETCHCONTENT_BASE_DIR}/json-c-src ${FETCHCONTENT_BASE_DIR}/json-c
-        COMMENT "Creating include symlink for json-c")
-    add_custom_target(json_h_symlink ALL
-        ln -sf ${FETCHCONTENT_BASE_DIR}/json-c-build/json.h ${FETCHCONTENT_BASE_DIR}/json-c/json.h
-        COMMENT "Creating symlink for json.h")
-    add_custom_target(json_config_h_symlink ALL
-        ln -sf ${FETCHCONTENT_BASE_DIR}/json-c-build/json_config.h ${FETCHCONTENT_BASE_DIR}/json-c/json_config.h
-        COMMENT "Creating symlink for json_config.h")
+    add_custom_command(
+        OUTPUT
+            ${FETCHCONTENT_BASE_DIR}/json-c-src/json.h
+        COMMAND
+            ln -sf ${FETCHCONTENT_BASE_DIR}/json-c-build/json.h ${FETCHCONTENT_BASE_DIR}/json-c-src/json.h
+        DEPENDS
+            ${FETCHCONTENT_BASE_DIR}/json-c-build/json.h
+    )
+
+    add_custom_target(json_h
+        DEPENDS ${FETCHCONTENT_BASE_DIR}/json-c-src/json.h
+        COMMENT "Creating json-c-src/json.h"
+    )
+
+    add_custom_command(
+        OUTPUT
+            ${FETCHCONTENT_BASE_DIR}/json-c
+        COMMAND
+            ln -sf ${FETCHCONTENT_BASE_DIR}/json-c-src ${FETCHCONTENT_BASE_DIR}/json-c
+        DEPENDS
+            ${FETCHCONTENT_BASE_DIR}/json-c-src
+            ${FETCHCONTENT_BASE_DIR}/json-c-src/json.h
+    )
+
+    add_custom_target(json_c_symlink
+        DEPENDS ${FETCHCONTENT_BASE_DIR}/json-c
+        COMMENT "Creating symlink for json-c include dir"
+    )
+
+    add_custom_command(
+        OUTPUT
+            ${FETCHCONTENT_BASE_DIR}/json-c/json.h
+            ${FETCHCONTENT_BASE_DIR}/json-c/json_config.h
+        COMMAND
+            ln -sf ${FETCHCONTENT_BASE_DIR}/json-c-build/json.h ${FETCHCONTENT_BASE_DIR}/json-c/json.h
+        COMMAND
+            ln -sf ${FETCHCONTENT_BASE_DIR}/json-c-build/json_config.h ${FETCHCONTENT_BASE_DIR}/json-c/json_config.h
+        DEPENDS
+            ${FETCHCONTENT_BASE_DIR}/json-c-build/json.h
+            ${FETCHCONTENT_BASE_DIR}/json-c-build/json_config.h
+            ${FETCHCONTENT_BASE_DIR}/json-c
+    )
+
+    add_custom_target(json_c_headers
+        DEPENDS
+            ${FETCHCONTENT_BASE_DIR}/json-c/json.h
+            ${FETCHCONTENT_BASE_DIR}/json-c/json_config.h
+        COMMENT "Creating symlinks for json-c headers"
+    )
 
     set(json-c_INCLUDE_DIRS ${json-c_ROOT}
         CACHE STRING "Path to FetchContent json-c" FORCE)
@@ -176,6 +240,7 @@ if (NOT json-c_FOUND)
     set(json-c_DEFINITIONS ""
         CACHE STRING "json-c preprocessor definitions" FORCE)
     set(json-c_FOUND TRUE CACHE BOOL "json-c found by FetchContent" FORCE)
+    set(json-c_IMPORTED TRUE CACHE BOOL "json-c imported from source" FORCE)
 endif(NOT json-c_FOUND)
 
 message(STATUS "json-c_ROOT ${json-c_ROOT}")
@@ -324,6 +389,16 @@ if (OPAE_WITH_LIBEDIT)
             CACHE STRING "Path to libedit libraries" FORCE)
         set(libedit_DEFINITIONS "" CACHE STRING "libedit built from source" FORCE)
         set(libedit_FOUND TRUE CACHE BOOL "libedit built from source" FORCE)
+
+        add_library(libedit_IMPORT SHARED IMPORTED)
+        set_property(
+            TARGET libedit_IMPORT
+            PROPERTY
+                IMPORTED_LOCATION "${libedit_LIBRARIES}"
+        )
+        set(libedit_IMPORTED TRUE CACHE BOOL "libedit imported from source" FORCE)
+        add_dependencies(libedit_IMPORT libedit)
+
     endif(NOT libedit_FOUND)
 
     message(STATUS "libedit_ROOT ${libedit_ROOT}")
@@ -428,6 +503,16 @@ if (OPAE_WITH_HWLOC)
             CACHE STRING "Path to hwloc libraries" FORCE)
         set(hwloc_DEFINITIONS "" CACHE STRING "hwloc built from source" FORCE)
         set(hwloc_FOUND TRUE CACHE BOOL "hwloc built from source" FORCE)
+
+        add_library(hwloc_IMPORT SHARED IMPORTED)
+        set_property(
+            TARGET hwloc_IMPORT
+            PROPERTY
+                IMPORTED_LOCATION "${hwloc_LIBRARIES}"
+        )
+        set(hwloc_IMPORTED TRUE CACHE BOOL "hwloc imported from source" FORCE)
+        add_dependencies(hwloc_IMPORT hwloc)
+
     endif(NOT hwloc_FOUND)
 
     message(STATUS "hwloc_ROOT ${hwloc_ROOT}")

--- a/binaries/fpgad/api/CMakeLists.txt
+++ b/binaries/fpgad/api/CMakeLists.txt
@@ -34,6 +34,7 @@ opae_add_shared_library(TARGET fpgad-api
     LIBS
         ${CMAKE_THREAD_LIBS_INIT}
         ${json-c_LIBRARIES}
+        ${uuid_LIBRARIES}
     VERSION ${OPAE_VERSION}
     SOVERSION ${OPAE_VERSION_MAJOR}
     COMPONENT toolfpgad_api

--- a/binaries/fpgad/plugins/fpgad-xfpga/CMakeLists.txt
+++ b/binaries/fpgad/plugins/fpgad-xfpga/CMakeLists.txt
@@ -36,6 +36,7 @@ opae_add_module_library(TARGET fpgad-xfpga
 target_include_directories(fpgad-xfpga
     PRIVATE
         ${OPAE_BIN_SOURCE}
-	${OPAE_LIB_SOURCE}/libopae-c
-	${OPAE_LIB_SOURCE}/libbitstream
+        ${OPAE_LIB_SOURCE}/libopae-c
+        ${OPAE_LIB_SOURCE}/libbitstream
+        ${json-c_INCLUDE_DIRS}
 )

--- a/binaries/opae.io/CMakeLists.txt
+++ b/binaries/opae.io/CMakeLists.txt
@@ -37,6 +37,10 @@ if (PLATFORM_SUPPORTS_VFIO AND OPAE_WITH_PYBIND11 AND OPAE_WITH_LIBEDIT)
         target_link_libraries(opae.io PRIVATE ${PYTHON_LIBRARIES} dl util ${libedit_LIBRARIES} opaevfio)
     endif()
 
+    if (libedit_IMPORTED)
+        add_dependencies(opae.io libedit_IMPORT)
+    endif(libedit_IMPORTED)
+
     target_include_directories(opae.io
         PUBLIC ${OPAE_INCLUDE_DIR}
         PRIVATE ${PYTHON_INCLUDE_DIRS}

--- a/cmake/modules/OPAECompiler.cmake
+++ b/cmake/modules/OPAECompiler.cmake
@@ -197,6 +197,34 @@ function(opae_add_executable)
 
     target_link_libraries(${OPAE_ADD_EXECUTABLE_TARGET} ${OPAE_ADD_EXECUTABLE_LIBS})
 
+    if (uuid_IMPORTED)
+        string(REGEX MATCH "${uuid_LIBRARIES}" NEED_EXTERNAL_UUID "${OPAE_ADD_EXECUTABLE_LIBS}")
+        if (NEED_EXTERNAL_UUID)
+            add_dependencies(${OPAE_ADD_EXECUTABLE_TARGET} uuid_IMPORT)
+        endif(NEED_EXTERNAL_UUID)
+    endif(uuid_IMPORTED)
+
+    if (json-c_IMPORTED)
+        string(REGEX MATCH "${json-c_LIBRARIES}" NEED_EXTERNAL_JSON_C "${OPAE_ADD_EXECUTABLE_LIBS}")
+        if (NEED_EXTERNAL_JSON_C)
+            add_dependencies(${OPAE_ADD_EXECUTABLE_TARGET} json_c_headers)
+        endif(NEED_EXTERNAL_JSON_C)
+    endif(json-c_IMPORTED)
+
+    if (libedit_IMPORTED)
+        string(REGEX MATCH "${libedit_LIBRARIES}" NEED_EXTERNAL_LIBEDIT "${OPAE_ADD_EXECUTABLE_LIBS}")
+	if (NEED_EXTERNAL_LIBEDIT)
+            add_dependencies(${OPAE_ADD_EXECUTABLE_TARGET} libedit_IMPORT)
+	endif(NEED_EXTERNAL_LIBEDIT)
+    endif(libedit_IMPORTED)
+
+    if (hwloc_IMPORTED)
+        string(REGEX MATCH "${hwloc_LIBRARIES}" NEED_EXTERNAL_HWLOC "${OPAE_ADD_EXECUTABLE_LIBS}")
+        if (NEED_EXTERNAL_HWLOC)
+            add_dependencies(${OPAE_ADD_EXECUTABLE_TARGET} hwloc_IMPORT)
+        endif(NEED_EXTERNAL_HWLOC)
+    endif(hwloc_IMPORTED)
+
     opae_coverage_build(TARGET ${OPAE_ADD_EXECUTABLE_TARGET} SOURCE ${OPAE_ADD_EXECUTABLE_SOURCE})
     set_install_rpath(${OPAE_ADD_EXECUTABLE_TARGET})
 
@@ -257,6 +285,34 @@ function(opae_add_shared_library)
 
     target_link_libraries(${OPAE_ADD_SHARED_LIBRARY_TARGET} ${OPAE_ADD_SHARED_LIBRARY_LIBS})
 
+    if (uuid_IMPORTED)
+        string(REGEX MATCH "${uuid_LIBRARIES}" NEED_EXTERNAL_UUID "${OPAE_ADD_SHARED_LIBRARY_LIBS}")
+        if (NEED_EXTERNAL_UUID)
+            add_dependencies(${OPAE_ADD_SHARED_LIBRARY_TARGET} uuid_IMPORT)
+        endif(NEED_EXTERNAL_UUID)
+    endif(uuid_IMPORTED)
+
+    if (json-c_IMPORTED)
+        string(REGEX MATCH "${json-c_LIBRARIES}" NEED_EXTERNAL_JSON_C "${OPAE_ADD_SHARED_LIBRARY_LIBS}")
+        if (NEED_EXTERNAL_JSON_C)
+            add_dependencies(${OPAE_ADD_SHARED_LIBRARY_TARGET} json_c_headers)
+        endif(NEED_EXTERNAL_JSON_C)
+    endif(json-c_IMPORTED)
+
+    if (libedit_IMPORTED)
+        string(REGEX MATCH "${libedit_LIBRARIES}" NEED_EXTERNAL_LIBEDIT "${OPAE_ADD_SHARED_LIBRARY_LIBS}")
+        if (NEED_EXTERNAL_LIBEDIT)
+            add_dependencies(${OPAE_ADD_SHARED_LIBRARY_TARGET} libedit_IMPORT)
+        endif(NEED_EXTERNAL_LIBEDIT)
+    endif(libedit_IMPORTED)
+
+    if (hwloc_IMPORTED)
+        string(REGEX MATCH "${hwloc_LIBRARIES}" NEED_EXTERNAL_HWLOC "${OPAE_ADD_SHARED_LIBRARY_LIBS}")
+        if (NEED_EXTERNAL_HWLOC)
+            add_dependencies(${OPAE_ADD_SHARED_LIBRARY_TARGET} hwloc_IMPORT)
+        endif(NEED_EXTERNAL_HWLOC)
+    endif(hwloc_IMPORTED)
+
     opae_coverage_build(TARGET ${OPAE_ADD_SHARED_LIBRARY_TARGET} SOURCE ${OPAE_ADD_SHARED_LIBRARY_SOURCE})
     set_install_rpath(${OPAE_ADD_SHARED_LIBRARY_TARGET})
 
@@ -311,6 +367,34 @@ function(opae_add_module_library)
     endif()
 
     target_link_libraries(${OPAE_ADD_MODULE_LIBRARY_TARGET} ${OPAE_ADD_MODULE_LIBRARY_LIBS})
+
+    if (uuid_IMPORTED)
+        string(REGEX MATCH "${uuid_LIBRARIES}" NEED_EXTERNAL_UUID "${OPAE_ADD_MODULE_LIBRARY_LIBS}")
+        if (NEED_EXTERNAL_UUID)
+            add_dependencies(${OPAE_ADD_MODULE_LIBRARY_TARGET} uuid_IMPORT)
+        endif(NEED_EXTERNAL_UUID)
+    endif(uuid_IMPORTED)
+
+    if (json-c_IMPORTED)
+        string(REGEX MATCH "${json-c_LIBRARIES}" NEED_EXTERNAL_JSON_C "${OPAE_ADD_MODULE_LIBRARY_LIBS}")
+        if (NEED_EXTERNAL_JSON_C)
+            add_dependencies(${OPAE_ADD_MODULE_LIBRARY_TARGET} json_c_headers)
+        endif(NEED_EXTERNAL_JSON_C)
+    endif(json-c_IMPORTED)
+
+    if (libedit_IMPORTED)
+        string(REGEX MATCH "${libedit_LIBRARIES}" NEED_EXTERNAL_LIBEDIT "${OPAE_ADD_MODULE_LIBRARY_LIBS}")
+        if (NEED_EXTERNAL_LIBEDIT)
+            add_dependencies(${OPAE_ADD_MODULE_LIBRARY_TARGET} libedit_IMPORT)
+        endif(NEED_EXTERNAL_LIBEDIT)
+    endif(libedit_IMPORTED)
+
+    if (hwloc_IMPORTED)
+        string(REGEX MATCH "${hwloc_LIBRARIES}" NEED_EXTERNAL_HWLOC "${OPAE_ADD_MODULE_LIBRARY_LIBS}")
+        if (NEED_EXTERNAL_HWLOC)
+            add_dependencies(${OPAE_ADD_MODULE_LIBRARY_TARGET} hwloc_IMPORT)
+        endif(NEED_EXTERNAL_HWLOC)
+    endif(hwloc_IMPORTED)
 
     opae_coverage_build(TARGET ${OPAE_ADD_MODULE_LIBRARY_TARGET} SOURCE ${OPAE_ADD_MODULE_LIBRARY_SOURCE})
 

--- a/cmake/modules/OPAETest.cmake
+++ b/cmake/modules/OPAETest.cmake
@@ -149,6 +149,34 @@ function(opae_test_add_static_lib)
     target_link_libraries(${OPAE_TEST_ADD_STATIC_LIB_TARGET}
         ${OPAE_TEST_ADD_STATIC_LIB_LIBS})
 
+    if (uuid_IMPORTED)
+        string(REGEX MATCH "${uuid_LIBRARIES}" NEED_EXTERNAL_UUID "${OPAE_TEST_ADD_STATIC_LIB_LIBS}")
+        if (NEED_EXTERNAL_UUID)
+            add_dependencies(${OPAE_TEST_ADD_STATIC_LIB_TARGET} uuid_IMPORT)
+        endif(NEED_EXTERNAL_UUID)
+    endif(uuid_IMPORTED)
+
+    if (json-c_IMPORTED)
+        string(REGEX MATCH "${json-c_LIBRARIES}" NEED_EXTERNAL_JSON_C "${OPAE_TEST_ADD_STATIC_LIB_LIBS}")
+        if (NEED_EXTERNAL_JSON_C)
+            add_dependencies(${OPAE_TEST_ADD_STATIC_LIB_TARGET} json_c_headers)
+        endif(NEED_EXTERNAL_JSON_C)
+    endif(json-c_IMPORTED)
+
+    if (libedit_IMPORTED)
+        string(REGEX MATCH "${libedit_LIBRARIES}" NEED_EXTERNAL_LIBEDIT "${OPAE_TEST_ADD_STATIC_LIB_LIBS}")
+	if (NEED_EXTERNAL_LIBEDIT)
+            add_dependencies(${OPAE_TEST_ADD_STATIC_LIB_TARGET} libedit_IMPORT)
+	endif(NEED_EXTERNAL_LIBEDIT)
+    endif(libedit_IMPORTED)
+
+    if (hwloc_IMPORTED)
+        string(REGEX MATCH "${hwloc_LIBRARIES}" NEED_EXTERNAL_HWLOC "${OPAE_TEST_ADD_STATIC_LIB_LIBS}")
+        if (NEED_EXTERNAL_HWLOC)
+            add_dependencies(${OPAE_TEST_ADD_STATIC_LIB_TARGET} hwloc_IMPORT)
+        endif(NEED_EXTERNAL_HWLOC)
+    endif(hwloc_IMPORTED)
+
     opae_coverage_build(TARGET ${OPAE_TEST_ADD_STATIC_LIB_TARGET}
         SOURCE ${OPAE_TEST_ADD_STATIC_LIB_SOURCE})
 endfunction()

--- a/libraries/libbitstream/CMakeLists.txt
+++ b/libraries/libbitstream/CMakeLists.txt
@@ -34,6 +34,8 @@ opae_add_shared_library(TARGET bitstream
     LIBS
         ${CMAKE_THREAD_LIBS_INIT}
         opae-c
+        ${json-c_LIBRARIES}
+        ${uuid_LIBRARIES}
     VERSION ${OPAE_VERSION}
     SOVERSION ${OPAE_VERSION_MAJOR}
     COMPONENT opaeclib

--- a/libraries/libopaecxx/CMakeLists.txt
+++ b/libraries/libopaecxx/CMakeLists.txt
@@ -41,6 +41,8 @@ set(OPAECXXCORE_SRC
 opae_add_shared_library(TARGET opae-cxx-core
     EXPORT opae-targets
     SOURCE ${OPAECXXCORE_SRC}
+    LIBS
+        ${uuid_LIBRARIES}
     VERSION ${OPAE_VERSION}
     SOVERSION ${OPAE_VERSION_MAJOR}
     COMPONENT opaecxxcorelib

--- a/libraries/plugins/xfpga/metrics/bmc/bmcdata.c
+++ b/libraries/plugins/xfpga/metrics/bmc/bmcdata.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2020, Intel Corporation
+// Copyright(c) 2018-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -32,7 +32,6 @@
 #include <opae/fpga.h>
 #ifndef _WIN32
 #include <unistd.h>
-#include <uuid/uuid.h>
 #endif
 #include <fcntl.h>
 #include <sys/types.h>

--- a/libraries/plugins/xfpga/metrics/bmc/bmcinfo.c
+++ b/libraries/plugins/xfpga/metrics/bmc/bmcinfo.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2022, Intel Corporation
+// Copyright(c) 2018-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -30,7 +30,6 @@
 
 #ifndef _WIN32
 #include <unistd.h>
-#include <uuid/uuid.h>
 #else
 #include <io.h>
 #endif

--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -17,7 +17,7 @@ fi
 mkdir -p coverage_files
 rm -rf coverage_files/*
 
-make -j 4
+make -j $(nproc)
 
 lcov --directory . --zerocounters
 lcov -c -i -d . -o coverage.base 2> /dev/null


### PR DESCRIPTION
Add the necessary dependencies so that parallel builds work again. Here are some observed data points. There seems to be a point of diminishing returns around -j 8:

cmake .. -DCMAKE_BUILD_TYPE=Debug -DOPAE_BUILD_TESTS=ON -DOPAE_ENABLE_MOCK=ON -DOPAE_BUILD_LEGACY=ON

make -j 4  5m5.137s
make -j 8  4m21.589s
make -j 12 5m35.980s
make -j 16 6m11.187s

Ah, `nproc` reports 8 cpu's. That explains it.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>