### PR TITLE
opae.admin: don't use pretty_version() for version

### DIFF
--- a/python/opae.admin/setup.py
+++ b/python/opae.admin/setup.py
@@ -1,4 +1,4 @@
-# Copyright(c) 2019-2022, Intel Corporation
+# Copyright(c) 2019-2023, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -24,11 +24,10 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 from setuptools import setup, find_namespace_packages
-from opae.admin.version import pretty_version
 
 setup(
     name="opae.admin",
-    version=pretty_version(),
+    version='1.4.3',
     packages=find_namespace_packages(include=['opae.*']),
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
When creating .deb and .rpm packages in CI, pretty_version() was observed to return the version string '1.4.3-'. This was causing setuptools to error out. Just use the hard-coded version to ensure that it's valid.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>