### PR TITLE
remove opae-c-archive static library

### DIFF
--- a/cmake/modules/OPAEPlugin.cmake
+++ b/cmake/modules/OPAEPlugin.cmake
@@ -58,6 +58,6 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${register_c}.c ${source_code})
         ${OPAE_ADD_SHARED_PLUGIN_SOURCE}
     )
     target_link_libraries(${OPAE_ADD_SHARED_PLUGIN_TARGET}
-        PUBLIC opae-c-archive
+        PUBLIC opae-c
     )
 endfunction()

--- a/libraries/libopae-c/CMakeLists.txt
+++ b/libraries/libopae-c/CMakeLists.txt
@@ -49,16 +49,6 @@ opae_add_shared_library(TARGET opae-c
     COMPONENT opaeclib
 )
 
-opae_add_static_library(TARGET opae-c-archive
-    EXPORT opae-targets
-    SOURCE ${SRC}
-    LIBS
-        dl
-        ${CMAKE_THREAD_LIBS_INIT}
-        ${json-c_LIBRARIES}
-        ${uuid_LIBRARIES}
-    COMPONENT opaeclib
-)
 
 install(FILES adapter.h props.h opae_int.h
     DESTINATION include/opae/plugin

--- a/opae.spec.fedora
+++ b/opae.spec.fedora
@@ -290,7 +290,7 @@ done
 %{_libdir}/libopae-cxx-core.so
 %{_libdir}/libopae-c++-utils.so
 %{_libdir}/libopae-c.so
-%{_libdir}/libopae-c-archive.a
+
 %{_libdir}/libbitstream.so
 %{_libdir}/libmml-stream.so
 %{_libdir}/libmml-srv.so


### PR DESCRIPTION
- OPAE-ASE module statically link opae-c-archive static library,
- Removed static library from OPAE-SDK , OPAE-ASE module dynamically likes opae-c library

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>