### PR TITLE
build: add deps on gtest imported libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -608,6 +608,41 @@ if (OPAE_BUILD_TESTS)
         set(GTEST_LIBRARY_DEBUG ${LIBRARY_OUTPUT_PATH}/libgtestd.so CACHE PATH "path to (debug) gtest library" FORCE)
         set(GTEST_MAIN_LIBRARY_DEBUG ${LIBRARY_OUTPUT_PATH}/libgtest_maind.so CACHE PATH "path to (debug) gtest main library" FORCE)
         set(GTest_FOUND TRUE CACHE BOOL "GTest found by FetchContent" FORCE)
+
+        add_library(gtest_IMPORT SHARED IMPORTED)
+        set_property(
+            TARGET gtest_IMPORT
+            PROPERTY
+                IMPORTED_LOCATION "${GTEST_LIBRARY}"
+        )
+        add_dependencies(gtest_IMPORT gtest)
+
+        add_library(gtest_MAIN_IMPORT SHARED IMPORTED)
+        set_property(
+            TARGET gtest_MAIN_IMPORT
+            PROPERTY
+                IMPORTED_LOCATION "${GTEST_MAIN_LIBRARY}"
+        )
+        add_dependencies(gtest_MAIN_IMPORT gtest)
+
+        add_library(gtest_IMPORT_DEBUG SHARED IMPORTED)
+        set_property(
+            TARGET gtest_IMPORT_DEBUG
+            PROPERTY
+                IMPORTED_LOCATION "${GTEST_LIBRARY_DEBUG}"
+        )
+        add_dependencies(gtest_IMPORT_DEBUG gtest)
+
+        add_library(gtest_MAIN_IMPORT_DEBUG SHARED IMPORTED)
+        set_property(
+            TARGET gtest_MAIN_IMPORT_DEBUG
+            PROPERTY
+                IMPORTED_LOCATION "${GTEST_MAIN_LIBRARY_DEBUG}"
+        )
+        add_dependencies(gtest_MAIN_IMPORT_DEBUG gtest)
+
+        set(GTEST_IMPORTED TRUE CACHE BOOL "gtest imported from source" FORCE)
+
     endif(NOT GTest_FOUND)
 
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/tests/framework/CMakeLists.txt
+++ b/tests/framework/CMakeLists.txt
@@ -53,6 +53,16 @@ opae_add_shared_library(TARGET test_system
 	${GTEST_LIB}
 )
 
+if (GTEST_IMPORTED)
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        add_dependencies(test_system gtest_IMPORT_DEBUG)
+        add_dependencies(test_system gtest_MAIN_IMPORT_DEBUG)
+    else()
+        add_dependencies(test_system gtest_IMPORT)
+        add_dependencies(test_system gtest_MAIN_IMPORT)
+    endif()
+endif(GTEST_IMPORTED)
+
 if (CXX_SUPPORTS_NO_ERROR_FRAME_ADDRESS)
   set_target_properties(test_system PROPERTIES COMPILE_FLAGS "-Wno-error=frame-address")
 endif()


### PR DESCRIPTION
Add the necessary dependencies between libtest_system.so and the gtest libraries in order to support parallel builds.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>