### PR TITLE
fix snyk scan error

### DIFF
--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -10,3 +10,4 @@ sphinx-markdown==1.0.2
 recommonmark==0.7.0
 breathe==4.33.1
 urllib3==1.26.7
+certifi==2022.12.7


### PR DESCRIPTION
    - upgrade certifi to version 2022.12.7 or higher.
    - Add  certifi==2022.12.7 to requirements.txt.

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>