### PR TITLE
opae.io: fix issues identified by static analysis

### DIFF
--- a/binaries/opae.io/main.h
+++ b/binaries/opae.io/main.h
@@ -219,6 +219,6 @@ private:
   opae_vfio *v_;
   vfio_device(opae_vfio *v)
     : v_(v){}
-
+  vfio_device(const vfio_device &);
 };
 


### PR DESCRIPTION
Declare the copy constructor as private but declare no actual member function for it so that the object becomes uncopyable. If an instance of the class were to be copied, then both instances would attempt to free the same pointer in close().

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>