### PR TITLE
python: fix errors found by static analysis

### DIFF
--- a/binaries/fpgadiag/opae/diag/fvlbypass.py
+++ b/binaries/fpgadiag/opae/diag/fvlbypass.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python3
-# Copyright(c) 2019, Intel Corporation
+# Copyright(c) 2019-2023, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -213,6 +213,7 @@ def get_sbdf_upl_mapping(sbdf):
 
     pci_dev_path = '/sys/bus/pci/devices/{}/resource2'.format(sbdf)
     addr = 0
+    next_afu_offset = 0
     while True:
         header = pci_read(pci_dev_path, addr)
         feature_type = (header >> DFH_TYPE_SHIFT) & DFH_TYPE_MASK

--- a/binaries/opae.io/opae/io/utils.py
+++ b/binaries/opae.io/opae/io/utils.py
@@ -1,4 +1,4 @@
-# Copyright(c) 2020-2022, Intel Corporation
+# Copyright(c) 2020-2023, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -269,8 +269,8 @@ class opae_register(Union):
         if value is not None:
             self.value = value
         if ACCESS_MODE == 32 and self.width == 64:
-            self.region.write32(self.offset, self._upper_mask & value)
-            self.region.write32(self.offset + 4, value >> 32)
+            self.region.write32(self.offset, self._upper_mask & self.value)
+            self.region.write32(self.offset + 4, self.value >> 32)
         else:
             self.wr(self.offset, self.value)
 

--- a/scripts/opae-clean.py
+++ b/scripts/opae-clean.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright(c) 2022, Intel Corporation
+# Copyright(c) 2022-2023, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -689,7 +689,7 @@ def deb_expand_variables(line, args):
 DEB_FILE_THEN_PATH_PATTERN = r'(?P<file>(\w|\.)+)\s+(?P<path>.*)'
 DEB_FILE_THEN_PATH_RE = re.compile(DEB_FILE_THEN_PATH_PATTERN, re.IGNORECASE)
 
-DEB_LIBRARY_FILE_GLOB_PATTERN = r'(?P<glob>(\w|[/])+lib(\w|[-+])+\.so\.\*)'
+DEB_LIBRARY_FILE_GLOB_PATTERN = r'^(?P<glob>(\w|[/])+lib(\w|[-+])+\.so\.\*)'
 DEB_LIBRARY_FILE_GLOB_RE = re.compile(DEB_LIBRARY_FILE_GLOB_PATTERN, re.IGNORECASE)
 
 DEB_LIBRARY_FILE_PATTERN = r'(?P<file>(\w|[/])+lib(\w|[-+])+\.(so|a))'


### PR DESCRIPTION
fvlbypass: uninitialized variable.
opae.io: use of wrong, invalid parameter.
opae-clean: anchoring of regex.

Signed-off-by: Tim Whisonant <tim.whisonant@intel.com>