### PR TITLE
Fix C6100 fpgainfo events power on time stamp

### DIFF
--- a/tests/board/test_board_c6100.cpp
+++ b/tests/board/test_board_c6100.cpp
@@ -140,8 +140,9 @@ void bel_print_sensors_status(struct bel_sensors_status *status);
 void bel_print_sensors_state(struct bel_sensors_state *state);
 void bel_print_power_off_status(struct bel_power_off_status *status,
                                 bool print_bits);
-void bel_print_power_on_status(struct bel_power_on_status *status,
-                               bool print_bits);
+void bel_print_power_on_status(struct bel_power_on_status* status,
+                            struct bel_timeof_day* timeof_day,
+                            bool print_bits);
 void bel_print(struct bel_event *event, bool print_sensors, bool print_bits);
 }
 
@@ -392,7 +393,7 @@ TEST_P(board_dfl_c6100_c_p, board_c6100_13) {
   struct bel_power_on_status power_on_status;
   memset(&power_on_status, 0x0, sizeof(power_on_status));
   power_on_status.header.magic = 0x53696C12;
-  EXPECT_NO_THROW(bel_print_power_on_status(&power_on_status, true));
+  EXPECT_NO_THROW(bel_print_power_on_status(&power_on_status, &timeof_day, true));
 
   struct bel_sensors_status sensors_status;
   memset(&sensors_status, 0x0, sizeof(sensors_status));


### PR DESCRIPTION
 SW should use the information in block with magic number '0x53696CF0' to derive power on event time stamp, and not the timestamp field of magic number '  0x53696C12'.
Power on status is logged immediately after power on.  Time of the day information is written by SW into a BMC register. This write will take some time after power on and hence with Power on log there is no timestamp value available. Because of this reason, second block 'time of the day offset' (block with magic number '0x53696CF0' ) is provided from BMC. BMC internally keeps track of time lapse after the power on and first ToD write by Host and provides the correct value by reverse calculation.  Please use this information to print the power on status time

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>