### PR TITLE
Fix PACSign fails on RHEL9 because of OpenSSL version 3.0.1 #2841

### DIFF
--- a/python/pacsign/pacsign/hsm_managers/openssl/openssl.py
+++ b/python/pacsign/pacsign/hsm_managers/openssl/openssl.py
@@ -320,7 +320,8 @@ class openssl:
 
             if (c_version == vers or
                 m.group('version') == vers or
-                m.group('version')[:-1] == vers):
+                m.group('version')[:-1] == vers or
+                vers == ''):
                 log.info('OpenSSL version "%s" matches "%s"', c_version, vers)
                 return dll
 
@@ -331,7 +332,7 @@ class openssl:
 
     def __init__(self, versions=[('libcrypto.so.1.1', '1.1.1'),
                                  ('libcrypto.so.1.1', 'OpenSSL 1.1.1k  FIPS 25 Mar 2021'),
-                                 ('libcrypto.so.3', 'OpenSSL 3.0.2 15 Mar 2022')]):
+                                 ('libcrypto.so.3', '')]):
         self.nanotime = None
 
         if _platform == "win32" or _platform == "win64":


### PR DESCRIPTION
The check for openssl version is relaxed to allow all versions of libcrypto.so.3 Ubuntu 22.04 uses 3.0.2, RHEL 9.0 and 9.1 uses 3.0.1. Several higher versions already exists.

Signed-off-by: Roger Christensen <rc@silicom.dk>