### PR TITLE
fpgareg: Enable the program for N501x cards in opae.cfg

### DIFF
--- a/opae.cfg
+++ b/opae.cfg
@@ -258,7 +258,12 @@
             "devices": [ "n5010_pf", "n5011_pf" ]
           }
         ],
-        "fpgareg": [],
+        "fpgareg": [
+          {
+            "enabled": true,
+            "devices": [ "n5010_pf", "n5011_pf" ]
+          }
+        ],
         "opae.io": [
           {
             "enabled": true,
@@ -318,7 +323,12 @@
             "devices": [ "n5013_pf" ]
           }
         ],
-        "fpgareg": [],
+        "fpgareg": [
+          {
+            "enabled": true,
+            "devices": [ "n5013_pf" ]
+          }
+        ],
         "opae.io": [
           {
             "enabled": true,
@@ -378,7 +388,12 @@
             "devices": [ "n5014_pf" ]
           }
         ],
-        "fpgareg": [],
+        "fpgareg": [
+          {
+            "enabled": true,
+            "devices": [ "n5014_pf" ]
+          }
+        ],
         "opae.io": [
           {
             "enabled": true,


### PR DESCRIPTION
The program also works for N501x cards. The pcie option walks the DFL. The bmc option shows the regmaps defined. The other options just do not find anything.

Signed-off-by: Roger Christensen <rc@silicom.dk>