### PR TITLE
vfio: changes in support of OpenCL MMD for gzip workload

### DIFF
--- a/include/opae/hash_map.h
+++ b/include/opae/hash_map.h
@@ -23,6 +23,17 @@
 // CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file opae/hash_map.h
+ * @brief A general-purpose hybrid array/list hash map implementation.
+ *
+ * Presents a generic interface for mapping key objects to value objects.
+ * Both keys and values may be arbitrary data structures. The user supplies
+ * the means by which the hash of values is generated and by which the
+ * keys are compared to each other.
+ */
+
 #ifndef __OPAE_HASH_MAP_H__
 #define __OPAE_HASH_MAP_H__
 #include <stdint.h>
@@ -33,30 +44,90 @@
 extern "C" {
 #endif // __cplusplus
 
+/** Flags used to initialize a hash map.
+ *
+ * OPAE_HASH_MAP_UNIQUE_KEYSPACE says that the user provides
+ * a guarantee that the key space is truly unique. In other words, when
+ * the provided hash function for keys A and B returns the same bucket
+ * index, the key comparison function when comparing A and B will never
+ * return a result saying that the keys are equal in value. This is helpful
+ * in situations where the key space is guaranteed to produce unique values,
+ * for example a memory allocator. When the key space is guaranteed to be
+ * unique, opae_hash_map_add() can implement a small performance improvement.
+ */
 typedef enum _opae_hash_map_flags {
 	OPAE_HASH_MAP_UNIQUE_KEYSPACE = (1u << 0)
 } opae_hash_map_flags;
 
+/**
+ * List link item.
+ *
+ * This structure provides the association between key and value.
+ * When the supplied hash function for keys A and B returns the same
+ * bucket index, both A and B can co-exist on the same list rooted
+ * at the bucket index.
+ */
 typedef struct _opae_hash_map_item {
 	void *key;
 	void *value;
 	struct _opae_hash_map_item *next;
 } opae_hash_map_item;
 
+/**
+ * Hash map object.
+ *
+ * This structure defines the internals of the hash map. Each of the
+ * parameters supplied to opae_hash_map_init() is stored in the structure.
+ * All parameters are required, except key_cleanup and value_cleanup,
+ * which may optionally be NULL.
+ */
 typedef struct _opae_hash_map {
 	uint32_t num_buckets;
 	uint32_t hash_seed;
 	opae_hash_map_item **buckets;
 	int flags;
-	void *cleanup_context;
-	uint32_t (*key_hash)(uint32_t num_buckets,	   ///< required
+	void *cleanup_context; ///< Optional second parameter to key_cleanup and value_cleanup
+	uint32_t (*key_hash)(uint32_t num_buckets,	   ///< (required)
 			     uint32_t hash_seed,
 			     void *key);
-	int (*key_compare)(void *keya, void *keyb);	   ///< required
-	void (*key_cleanup)(void *key, void *context);	   ///< optional
-	void (*value_cleanup)(void *value, void *context); ///< optional
+	int (*key_compare)(void *keya, void *keyb);	   ///< (required)
+	void (*key_cleanup)(void *key, void *context);	   ///< (optional)
+	void (*value_cleanup)(void *value, void *context); ///< (optional)
 } opae_hash_map;
 
+/**
+ * Initialize a hash map
+ *
+ * Populates the hash map data structure and allocates the buckets
+ * array.
+ *
+ * @param[out] hm            A pointer to the storage for the hash map object.
+ * @param[in]  num_buckets   The desired size of the buckets array. Each array
+ *                           entry may be empty (NULL), or may contain a list
+ *                           of opae_hash_map_item structures for which the given
+ *                           key_hash function returned the same key hash value.
+ * @param[in]  hash_seed     A seed value used during key hash computation. This
+ *                           value will be the hash_seed parameter to the key hash
+ *                           function.
+ * @param[in]  flags         Initialization flags. See opae_hash_map_flags.
+ * @param[in]  key_hash      A pointer to a function that produces the has value,
+ *                           given the number of buckets, the hash seed, and the key.
+ *                           Valid values are between 0 and num_buckets - 1, inclusively.
+ * @param[in]  key_compare   A pointer to a function that compares two keys. The return
+ *                           value is similar to that of strcmp(), where a negative value
+ *                           means that keya < keyb, 0 means that keya == keyb, and a positive
+ *                           values means that keya > keyb.
+ * @param[in]  key_cleanup   A pointer to a function that is called when a key is being
+ *                           removed from the map. This function is optional and may be
+ *                           NULL. When supplied, the function is responsible for freeing
+ *                           any resources allocated when the key was created.
+ * @param[in]  value_cleanup A pointer to a function that is called when a value is
+ *                           being removed from the map. This function is optional and may
+ *                           be NULL. When supplied, the function is responsible for freeing
+ *                           any resources allocated when the value was created.
+ * @returns FPGA_OK on success, FPGA_INVALID_PARAM if any of the required parameters are
+ *          NULL, or FPGA_NO_MEMORY if the bucket array could not be allocated.
+ */
 fpga_result opae_hash_map_init(opae_hash_map *hm,
 			       uint32_t num_buckets,
 			       uint32_t hash_seed,
@@ -68,25 +139,93 @@ fpga_result opae_hash_map_init(opae_hash_map *hm,
 			       void (*key_cleanup)(void *key, void *context),
 			       void (*value_cleanup)(void *value, void *context));
 
+/**
+ * Map a key to a value
+ *
+ * Inserts a mapping from key to value in the given hash map object.
+ * Subsequent calls to opae_hash_map_find() that are given the key
+ * will retrieve the value.
+ *
+ * @param[in, out] hm    A pointer to the storage for the hash map object.
+ * @param[in]      key   The hash map key.
+ * @param[in]      value The hash map value.
+ * @returns FPGA_OK on success, FPGA_INVALID_PARAM if hm is NULL, FPGA_NO_MEMORY
+ *          if malloc() fails when allocating the list item, or FPGA_INVALID_PARAM
+ *          if the key hash produced by key_hash is out of bounds.
+ */
 fpga_result opae_hash_map_add(opae_hash_map *hm,
 			      void *key,
 			      void *value);
 
+/**
+ * Retrieve the value for a given key
+ *
+ * Given a key that was previously passed to opae_hash_map_add(), retrieve
+ * its associated value.
+ *
+ * @param[in] hm    A pointer to the storage for the hash map object.
+ * @param[in] key   The hash map key.
+ * @param[in] value A pointer to receive the hash map value.
+ * @returns FPGA_OK on success, FPGA_INVALID_PARAM if hm is NULL or if the
+ *          key hash produced by key_hash is out of bounds, or FPGA_NOT_FOUND
+ *          if the given key was not found in the hash map.
+ */
 fpga_result opae_hash_map_find(opae_hash_map *hm,
 			       void *key,
 			       void **value);
 
+/**
+ * Remove a key/value association
+ *
+ * Given a key that was previously passed to opae_hash_map_add(), remove the
+ * key and its associated value, calling the cleanup functions as needed.
+ *
+ * @param[in, out] hm    A pointer to the storage for the hash map object.
+ * @param[in]      key   The hash map key.
+ * @returns FPGA_OK on success, FPGA_INVALID_PARAM when hm is NULL or when the
+ *          key hash produced by key_hash is out of bounds, or FPGA_NOT_FOUND if
+ *          the key is not found in the hash map.
+ */ 
 fpga_result opae_hash_map_remove(opae_hash_map *hm,
 				 void *key);
 
+/**
+ * Tear down a hash map
+ *
+ * Given a hash map that was previously initialized by opae_hash_map_init(),
+ * destroy the hash map, releasing all keys, values, and the bucket array.
+ *
+ * @param[in, out] hm A pointer to the storage for the hash map object.
+ * @returns FPGA_OK on success or FPGA_INVALID_PARAM is hm is NULL.
+ */
 fpga_result opae_hash_map_destroy(opae_hash_map *hm);
 
+/**
+ * Determine whether a hash map is empty
+ *
+ * @param[in] hm A pointer to the storage for the hash map object.
+ * @returns true if there are not key/value mappings present, false
+ *          otherwise.
+ */
 bool opae_hash_map_is_empty(opae_hash_map *hm);
 
+/**
+ * Convenience hash function for arbitrary pointers/64-bit values.
+ *
+ * Simply converts the key to a uint64_t and then performs the
+ * modulus operation on the configured num_buckets. hash_seed is
+ * unused.
+ */
 uint32_t opae_u64_key_hash(uint32_t num_buckets,
 			   uint32_t hash_seed,
 			   void *key);
 
+/**
+ * Convenience key comparison function for 64-bit values.
+ *
+ * Simply converts the key pointers to uint64_t's and performs
+ * unsigned integer comparison.
+ */
 int opae_u64_key_compare(void *keya, void *keyb);
 
 #ifdef __cplusplus

--- a/include/opae/hash_map.h
+++ b/include/opae/hash_map.h
@@ -1,0 +1,92 @@
+// Copyright(c) 2022-2023, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#ifndef __OPAE_HASH_MAP_H__
+#define __OPAE_HASH_MAP_H__
+#include <stdint.h>
+#include <stdbool.h>
+#include <opae/types_enum.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+typedef struct _opae_hash_map_item {
+	void *key;
+	void *value;
+	struct _opae_hash_map_item *next;
+} opae_hash_map_item;
+
+typedef int (*opae_hash_map_key_compare)(void *, void *);
+
+typedef struct _opae_hash_map {
+	uint32_t num_buckets;
+	uint32_t hash_seed;
+	opae_hash_map_item **buckets;
+	void *cleanup_context;
+	uint32_t (*key_hash)(uint32_t num_buckets,	   ///< required
+			     uint32_t hash_seed,
+			     void *key);
+	int (*key_compare)(void *keya, void *keyb);	   ///< required
+	void (*key_cleanup)(void *key, void *context);	   ///< optional
+	void (*value_cleanup)(void *value, void *context); ///< optional
+} opae_hash_map;
+
+fpga_result opae_hash_map_init(opae_hash_map *hm,
+			       uint32_t num_buckets,
+			       uint32_t hash_seed,
+			       uint32_t (*key_hash)(uint32_t num_buckets,
+						    uint32_t hash_seed,
+						    void *key),
+			       int (*key_compare)(void *keya, void *keyb),
+			       void (*key_cleanup)(void *key, void *context),
+			       void (*value_cleanup)(void *value, void *context));
+
+fpga_result opae_hash_map_add(opae_hash_map *hm,
+			      void *key,
+			      void *value);
+
+fpga_result opae_hash_map_find(opae_hash_map *hm,
+			       void *key,
+			       void **value);
+
+fpga_result opae_hash_map_remove(opae_hash_map *hm,
+				 void *key);
+
+fpga_result opae_hash_map_destroy(opae_hash_map *hm);
+
+bool opae_hash_map_is_empty(opae_hash_map *hm);
+
+uint32_t opae_u64_key_hash(uint32_t num_buckets,
+			   uint32_t hash_seed,
+			   void *key);
+
+int opae_u64_key_compare(void *keya, void *keyb);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
+#endif // __OPAE_HASH_MAP_H__

--- a/include/opae/hash_map.h
+++ b/include/opae/hash_map.h
@@ -110,7 +110,7 @@ typedef struct _opae_hash_map {
  *                           value will be the hash_seed parameter to the key hash
  *                           function.
  * @param[in]  flags         Initialization flags. See opae_hash_map_flags.
- * @param[in]  key_hash      A pointer to a function that produces the has value,
+ * @param[in]  key_hash      A pointer to a function that produces the hash value,
  *                           given the number of buckets, the hash seed, and the key.
  *                           Valid values are between 0 and num_buckets - 1, inclusively.
  * @param[in]  key_compare   A pointer to a function that compares two keys. The return
@@ -204,7 +204,7 @@ fpga_result opae_hash_map_destroy(opae_hash_map *hm);
  * Determine whether a hash map is empty
  *
  * @param[in] hm A pointer to the storage for the hash map object.
- * @returns true if there are not key/value mappings present, false
+ * @returns true if there are no key/value mappings present, false
  *          otherwise.
  */
 bool opae_hash_map_is_empty(opae_hash_map *hm);
@@ -213,7 +213,7 @@ bool opae_hash_map_is_empty(opae_hash_map *hm);
  * Convenience hash function for arbitrary pointers/64-bit values.
  *
  * Simply converts the key to a uint64_t and then performs the
- * modulus operation on the configured num_buckets. hash_seed is
+ * modulus operation with the configured num_buckets. hash_seed is
  * unused.
  */
 uint32_t opae_u64_key_hash(uint32_t num_buckets,

--- a/include/opae/hash_map.h
+++ b/include/opae/hash_map.h
@@ -29,6 +29,10 @@
 #include <stdbool.h>
 #include <opae/types_enum.h>
 
+#ifndef UNUSED_PARAM
+#define UNUSED_PARAM(x) ((void)(x))
+#endif // UNUSED_PARAM
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -83,11 +87,29 @@ fpga_result opae_hash_map_destroy(opae_hash_map *hm);
 
 bool opae_hash_map_is_empty(opae_hash_map *hm);
 
+static inline
 uint32_t opae_u64_key_hash(uint32_t num_buckets,
 			   uint32_t hash_seed,
-			   void *key);
+			   void *key)
+{
+	UNUSED_PARAM(hash_seed);
+	uint64_t ukey = (uint64_t)key;
+	return (uint32_t)(ukey % num_buckets);
+}
 
-int opae_u64_key_compare(void *keya, void *keyb);
+static inline
+int opae_u64_key_compare(void *keya, void *keyb)
+{
+	uint64_t a = (uint64_t)keya;
+	uint64_t b = (uint64_t)keyb;
+
+	if (a < b)
+		return -1;
+	else if (a > b)
+		return 1;
+	else
+		return 0;
+}
 
 #ifdef __cplusplus
 }

--- a/include/opae/hash_map.h
+++ b/include/opae/hash_map.h
@@ -29,10 +29,6 @@
 #include <stdbool.h>
 #include <opae/types_enum.h>
 
-#ifndef UNUSED_PARAM
-#define UNUSED_PARAM(x) ((void)(x))
-#endif // UNUSED_PARAM
-
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -87,29 +83,11 @@ fpga_result opae_hash_map_destroy(opae_hash_map *hm);
 
 bool opae_hash_map_is_empty(opae_hash_map *hm);
 
-static inline
 uint32_t opae_u64_key_hash(uint32_t num_buckets,
 			   uint32_t hash_seed,
-			   void *key)
-{
-	UNUSED_PARAM(hash_seed);
-	uint64_t ukey = (uint64_t)key;
-	return (uint32_t)(ukey % num_buckets);
-}
+			   void *key);
 
-static inline
-int opae_u64_key_compare(void *keya, void *keyb)
-{
-	uint64_t a = (uint64_t)keya;
-	uint64_t b = (uint64_t)keyb;
-
-	if (a < b)
-		return -1;
-	else if (a > b)
-		return 1;
-	else
-		return 0;
-}
+int opae_u64_key_compare(void *keya, void *keyb);
 
 #ifdef __cplusplus
 }

--- a/include/opae/hash_map.h
+++ b/include/opae/hash_map.h
@@ -33,18 +33,21 @@
 extern "C" {
 #endif // __cplusplus
 
+typedef enum _opae_hash_map_flags {
+	OPAE_HASH_MAP_UNIQUE_KEYSPACE = (1u << 0)
+} opae_hash_map_flags;
+
 typedef struct _opae_hash_map_item {
 	void *key;
 	void *value;
 	struct _opae_hash_map_item *next;
 } opae_hash_map_item;
 
-typedef int (*opae_hash_map_key_compare)(void *, void *);
-
 typedef struct _opae_hash_map {
 	uint32_t num_buckets;
 	uint32_t hash_seed;
 	opae_hash_map_item **buckets;
+	int flags;
 	void *cleanup_context;
 	uint32_t (*key_hash)(uint32_t num_buckets,	   ///< required
 			     uint32_t hash_seed,
@@ -57,6 +60,7 @@ typedef struct _opae_hash_map {
 fpga_result opae_hash_map_init(opae_hash_map *hm,
 			       uint32_t num_buckets,
 			       uint32_t hash_seed,
+			       int flags,
 			       uint32_t (*key_hash)(uint32_t num_buckets,
 						    uint32_t hash_seed,
 						    void *key),

--- a/libraries/libopaemem/CMakeLists.txt
+++ b/libraries/libopaemem/CMakeLists.txt
@@ -28,6 +28,7 @@ opae_add_shared_library(TARGET opaemem
     EXPORT opae-targets
     SOURCE
         mem_alloc.c
+	hash_map.c
         ${opae-test_ROOT}/framework/mock/opae_std.c
     VERSION ${OPAE_VERSION}
     SOVERSION ${OPAE_VERSION_MAJOR}

--- a/libraries/libopaemem/hash_map.c
+++ b/libraries/libopaemem/hash_map.c
@@ -174,6 +174,12 @@ fpga_result opae_hash_map_find(opae_hash_map *hm,
 	key_hash = hm->key_hash(hm->num_buckets,
 				hm->hash_seed,
 				key);
+	if (key_hash >= hm->num_buckets) {
+		ERR("key hash returned %u which is "
+		    "greater than num_buckets(%u)\n",
+		    key_hash, hm->num_buckets);
+		return FPGA_INVALID_PARAM;
+	}
 
 	list = hm->buckets[key_hash];
 
@@ -204,6 +210,12 @@ fpga_result opae_hash_map_remove(opae_hash_map *hm,
 	key_hash = hm->key_hash(hm->num_buckets,
 				hm->hash_seed,
 				key);
+	if (key_hash >= hm->num_buckets) {
+		ERR("key hash returned %u which is "
+		    "greater than num_buckets(%u)\n",
+		    key_hash, hm->num_buckets);
+		return FPGA_INVALID_PARAM;
+	}
 
 	list = hm->buckets[key_hash];
 	if (!list)

--- a/libraries/libopaemem/hash_map.c
+++ b/libraries/libopaemem/hash_map.c
@@ -31,6 +31,10 @@
 #include <opae/hash_map.h>
 #include "mock/opae_std.h"
 
+#ifndef UNUSED_PARAM
+#define UNUSED_PARAM(x) ((void)(x))
+#endif // UNUSED_PARAM
+
 #define __SHORT_FILE__                                    \
 ({                                                        \
 	const char *file = __FILE__;                      \
@@ -119,14 +123,9 @@ fpga_result opae_hash_map_add(opae_hash_map *hm,
 		return FPGA_NO_MEMORY;
 	}
 
-	if (hm->key_hash == opae_u64_key_hash)
-		key_hash = opae_u64_key_hash(hm->num_buckets,
-					     hm->hash_seed,
-					     key);
-	else
-		key_hash = hm->key_hash(hm->num_buckets,
-					hm->hash_seed,
-					key);
+	key_hash = hm->key_hash(hm->num_buckets,
+				hm->hash_seed,
+				key);
 
 	if (key_hash >= hm->num_buckets) {
 		ERR("key hash returned %u which is "
@@ -192,14 +191,9 @@ fpga_result opae_hash_map_find(opae_hash_map *hm,
 		return FPGA_INVALID_PARAM;
 	}
 
-	if (hm->key_hash == opae_u64_key_hash)
-		key_hash = opae_u64_key_hash(hm->num_buckets,
-					     hm->hash_seed,
-					     key);
-	else
-		key_hash = hm->key_hash(hm->num_buckets,
-					hm->hash_seed,
-					key);
+	key_hash = hm->key_hash(hm->num_buckets,
+				hm->hash_seed,
+				key);
 
 	if (key_hash >= hm->num_buckets) {
 		ERR("key hash returned %u which is "
@@ -241,14 +235,9 @@ fpga_result opae_hash_map_remove(opae_hash_map *hm,
 		return FPGA_INVALID_PARAM;
 	}
 
-	if (hm->key_hash == opae_u64_key_hash)
-		key_hash = opae_u64_key_hash(hm->num_buckets,
-					     hm->hash_seed,
-					     key);
-	else
-		key_hash = hm->key_hash(hm->num_buckets,
-					hm->hash_seed,
-					key);
+	key_hash = hm->key_hash(hm->num_buckets,
+				hm->hash_seed,
+				key);
 
 	if (key_hash >= hm->num_buckets) {
 		ERR("key hash returned %u which is "
@@ -334,4 +323,26 @@ bool opae_hash_map_is_empty(opae_hash_map *hm)
 	}
 
 	return true;
+}
+
+uint32_t opae_u64_key_hash(uint32_t num_buckets,
+			   uint32_t hash_seed,
+			   void *key)
+{
+	UNUSED_PARAM(hash_seed);
+	uint64_t ukey = (uint64_t)key;
+	return (uint32_t)(ukey % num_buckets);
+}
+
+inline int opae_u64_key_compare(void *keya, void *keyb)
+{
+	uint64_t a = (uint64_t)keya;
+	uint64_t b = (uint64_t)keyb;
+
+	if (a < b)
+		return -1;
+	else if (a > b)
+		return 1;
+	else
+		return 0;
 }

--- a/libraries/libopaemem/hash_map.c
+++ b/libraries/libopaemem/hash_map.c
@@ -1,0 +1,291 @@
+// Copyright(c) 2022-2023, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#include <opae/log.h>
+#include <opae/hash_map.h>
+#include "mock/opae_std.h"
+
+#ifndef UNUSED_PARAM
+#define UNUSED_PARAM(x) ((void)(x))
+#endif // UNUSED_PARAM
+
+#define __SHORT_FILE__                                    \
+({                                                        \
+	const char *file = __FILE__;                      \
+	const char *p = file;                             \
+	while (*p)                                        \
+		++p;                                      \
+	while ((p > file) && ('/' != *p) && ('\\' != *p)) \
+		--p;                                      \
+	if (p > file)                                     \
+		++p;                                      \
+	p;                                                \
+})
+
+#define ERR(format, ...)                               \
+fprintf(stderr, "%s:%u:%s() **ERROR** [%s] : " format, \
+	__SHORT_FILE__, __LINE__, __func__, strerror(errno), ##__VA_ARGS__)
+
+fpga_result opae_hash_map_init(opae_hash_map *hm,
+			       uint32_t num_buckets,
+			       uint32_t hash_seed,
+			       uint32_t (*key_hash)(uint32_t num_buckets,
+						    uint32_t hash_seed,
+						    void *key),
+			       int (*key_compare)(void *keya, void *keyb),
+			       void (*key_cleanup)(void *key, void *context),
+			       void (*value_cleanup)(void *value, void *context))
+{
+	if (!hm || !key_hash || !key_compare) {
+		ERR("NULL pointer(s)");
+		return FPGA_INVALID_PARAM;
+	}
+
+	memset(hm, 0, sizeof(*hm));
+
+	hm->buckets = (opae_hash_map_item **)
+			opae_calloc(num_buckets,
+				    sizeof(opae_hash_map_item *));
+	if (!hm->buckets) {
+		ERR("calloc() failed");
+		return FPGA_NO_MEMORY;
+	}
+
+	hm->num_buckets = num_buckets;
+	hm->hash_seed = hash_seed;
+	hm->key_hash = key_hash;
+	hm->key_compare = key_compare;
+	hm->key_cleanup = key_cleanup;
+	hm->value_cleanup = value_cleanup;
+
+	return FPGA_OK;
+}
+
+STATIC opae_hash_map_item *
+opae_hash_map_alloc_item(void *key, void *value)
+{
+	opae_hash_map_item *item;
+	item = (opae_hash_map_item *)
+		opae_malloc(sizeof(opae_hash_map_item));
+	if (item) {
+		item->key = key;
+		item->value = value;
+		item->next = NULL;
+	}
+	return item;
+}
+
+fpga_result opae_hash_map_add(opae_hash_map *hm,
+			      void *key,
+			      void *value)
+{
+	uint32_t key_hash;
+	opae_hash_map_item *item;
+	opae_hash_map_item *list;
+
+	if (!hm) {
+		ERR("NULL pointer");
+		return FPGA_INVALID_PARAM;
+	}
+
+	item = opae_hash_map_alloc_item(key, value);
+	if (!item) {
+		ERR("malloc() failed");
+		return FPGA_NO_MEMORY;
+	}
+
+	key_hash = hm->key_hash(hm->num_buckets,
+				hm->hash_seed,
+				key);
+
+	list = hm->buckets[key_hash];
+	if (!list) {
+		// Bucket was empty. Fill it.
+		hm->buckets[key_hash] = item;
+		return FPGA_OK;
+	}
+
+	// Bucket not empty. Do we have a key collision?
+	while (list) {
+		if (!hm->key_compare(key, list->key)) {
+			// Key collision.
+			opae_free(item);
+			if (hm->value_cleanup)
+				hm->value_cleanup(list->value, hm->cleanup_context);
+			list->value = value; // Replace value only.
+			return FPGA_OK;
+		}
+		list = list->next;
+	}
+
+	// No key collision. Add item to the list.
+	item->next = hm->buckets[key_hash];
+	hm->buckets[key_hash] = item;
+
+	return FPGA_OK;
+}
+
+fpga_result opae_hash_map_find(opae_hash_map *hm,
+			       void *key,
+			       void **value)
+{
+	uint32_t key_hash;
+	opae_hash_map_item *list;
+
+	if (!hm) {
+		ERR("NULL pointer");
+		return FPGA_INVALID_PARAM;
+	}
+
+	key_hash = hm->key_hash(hm->num_buckets,
+				hm->hash_seed,
+				key);
+
+	list = hm->buckets[key_hash];
+
+	while (list) {
+		if (!hm->key_compare(key, list->key)) {
+			if (value)
+				*value = list->value;
+			return FPGA_OK;
+		}
+		list = list->next;
+	}
+
+	return FPGA_NOT_FOUND;
+}
+
+fpga_result opae_hash_map_remove(opae_hash_map *hm,
+				 void *key)
+{
+	uint32_t key_hash;
+	opae_hash_map_item *prev = NULL;
+	opae_hash_map_item *list;
+
+	if (!hm) {
+		ERR("NULL pointer");
+		return FPGA_INVALID_PARAM;
+	}
+
+	key_hash = hm->key_hash(hm->num_buckets,
+				hm->hash_seed,
+				key);
+
+	list = hm->buckets[key_hash];
+	if (!list)
+		return FPGA_NOT_FOUND;
+
+	while (list) {
+		if (!hm->key_compare(key, list->key))
+			break;
+		prev = list;
+		list = list->next;
+	}
+
+	if (!list)
+		return FPGA_NOT_FOUND;
+
+	if (!prev) {
+		// Key found at head of list.
+		hm->buckets[key_hash] = list->next;
+	} else {
+		prev->next = list->next;
+	}
+
+	if (hm->key_cleanup)
+		hm->key_cleanup(list->key, hm->cleanup_context);
+	if (hm->value_cleanup)
+		hm->value_cleanup(list->value, hm->cleanup_context);
+	opae_free(list);
+
+	return FPGA_OK;
+}
+
+fpga_result opae_hash_map_destroy(opae_hash_map *hm)
+{
+	uint32_t i;
+
+	if (!hm) {
+		ERR("NULL pointer");
+		return FPGA_INVALID_PARAM;
+	}
+
+	for (i = 0 ; i < hm->num_buckets ; ++i) {
+		opae_hash_map_item *item;
+		item = hm->buckets[i];
+		while (item) {
+			opae_hash_map_item *trash;
+			trash = item;
+			item = item->next;
+			if (hm->key_cleanup)
+				hm->key_cleanup(trash->key, hm->cleanup_context);
+			if (hm->value_cleanup)
+				hm->value_cleanup(trash->value, hm->cleanup_context);
+			opae_free(trash);
+		}
+	}
+
+	opae_free(hm->buckets);
+	memset(hm, 0, sizeof(*hm));
+
+	return FPGA_OK;
+}
+
+bool opae_hash_map_is_empty(opae_hash_map *hm)
+{
+	uint32_t i;
+
+	for (i = 0 ; i < hm->num_buckets ; ++i) {
+		if (hm->buckets[i])
+			return false;
+	}
+
+	return true;
+}
+
+uint32_t opae_u64_key_hash(uint32_t num_buckets, uint32_t hash_seed, void *key)
+{
+	UNUSED_PARAM(hash_seed);
+	uint64_t remote_id = (uint64_t)key;
+	uint64_t hash = remote_id % 17659;
+	return (uint32_t)(hash % num_buckets);
+}
+
+int opae_u64_key_compare(void *keya, void *keyb)
+{
+	uint64_t a = (uint64_t)keya;
+	uint64_t b = (uint64_t)keyb;
+
+	if (a < b)
+		return -1;
+	else if (a > b)
+		return 1;
+	else
+		return 0;
+}

--- a/libraries/libopaemem/hash_map.c
+++ b/libraries/libopaemem/hash_map.c
@@ -108,6 +108,7 @@ fpga_result opae_hash_map_add(opae_hash_map *hm,
 	uint32_t key_hash;
 	opae_hash_map_item *item;
 	opae_hash_map_item *list;
+	opae_hash_map_item *prev;
 
 	if (!hm) {
 		ERR("NULL pointer");
@@ -138,6 +139,7 @@ fpga_result opae_hash_map_add(opae_hash_map *hm,
 	}
 
 	// Bucket not empty. Do we have a key collision?
+	prev = NULL;
 	while (list) {
 		if (!hm->key_compare(key, list->key)) {
 			// Key collision.
@@ -147,12 +149,12 @@ fpga_result opae_hash_map_add(opae_hash_map *hm,
 			list->value = value; // Replace value only.
 			return FPGA_OK;
 		}
+		prev = list;
 		list = list->next;
 	}
 
-	// No key collision. Add item to the list.
-	item->next = hm->buckets[key_hash];
-	hm->buckets[key_hash] = item;
+	// No key collision. Add item to the end of list.
+	prev->next = item;
 
 	return FPGA_OK;
 }

--- a/libraries/libopaemem/hash_map.c
+++ b/libraries/libopaemem/hash_map.c
@@ -123,6 +123,12 @@ fpga_result opae_hash_map_add(opae_hash_map *hm,
 	key_hash = hm->key_hash(hm->num_buckets,
 				hm->hash_seed,
 				key);
+	if (key_hash >= hm->num_buckets) {
+		ERR("key hash returned %u which is "
+		    "greater than num_buckets(%u)\n",
+		    key_hash, hm->num_buckets);
+		return FPGA_INVALID_PARAM;
+	}
 
 	list = hm->buckets[key_hash];
 	if (!list) {

--- a/libraries/libopaevfio/opaevfio.c
+++ b/libraries/libopaevfio/opaevfio.c
@@ -1145,7 +1145,7 @@ STATIC int opae_vfio_init(struct opae_vfio *v,
 	mem_alloc_init(&v->iova_alloc);
 
 	result = opae_hash_map_init(&v->cont_buffers,
-				    16384, // num_buckets
+				    19441, // num_buckets
 				    0,     // hash_seed
 				    OPAE_HASH_MAP_UNIQUE_KEYSPACE,
 				    opae_u64_key_hash,

--- a/libraries/libopaevfio/opaevfio.c
+++ b/libraries/libopaevfio/opaevfio.c
@@ -1147,6 +1147,7 @@ STATIC int opae_vfio_init(struct opae_vfio *v,
 	result = opae_hash_map_init(&v->cont_buffers,
 				    16384, // num_buckets
 				    0,     // hash_seed
+				    OPAE_HASH_MAP_UNIQUE_KEYSPACE,
 				    opae_u64_key_hash,
 				    opae_u64_key_compare,
 				    NULL,  // key_cleanup

--- a/libraries/libopaevfio/opaevfio.c
+++ b/libraries/libopaevfio/opaevfio.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2020-2022, Intel Corporation
+// Copyright(c) 2020-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -483,8 +483,7 @@ opae_vfio_destroy_buffer(struct opae_vfio *, struct opae_vfio_buffer *);
 STATIC void opae_vfio_destroy(struct opae_vfio *v)
 {
 	// destroy buffers before we close any FDs
-	opae_vfio_destroy_buffer(v, v->cont_buffers);
-	v->cont_buffers = NULL;
+	opae_hash_map_destroy(&v->cont_buffers);
 
 	opae_vfio_device_destroy(&v->device);
 	opae_vfio_group_destroy(&v->group);
@@ -629,7 +628,6 @@ opae_vfio_create_buffer(uint8_t *vaddr,
 		b->buffer_size = size;
 		b->buffer_iova = iova;
 		b->flags = flags;
-		b->next = NULL;
 	}
 	return b;
 }
@@ -640,30 +638,25 @@ opae_vfio_destroy_buffer(struct opae_vfio *v,
 {
 	struct vfio_iommu_type1_dma_unmap dma_unmap;
 
-	while (b) {
-		struct opae_vfio_buffer *trash = b;
-		b = b->next;
+	memset(&dma_unmap, 0, sizeof(dma_unmap));
+	dma_unmap.argsz = sizeof(dma_unmap);
+	dma_unmap.iova = b->buffer_iova;
+	dma_unmap.size = b->buffer_size;
 
-		memset(&dma_unmap, 0, sizeof(dma_unmap));
-		dma_unmap.argsz = sizeof(dma_unmap);
-		dma_unmap.iova = trash->buffer_iova;
-		dma_unmap.size = trash->buffer_size;
+	if (opae_ioctl(v->cont_fd, VFIO_IOMMU_UNMAP_DMA, &dma_unmap) < 0)
+		ERR("ioctl(%d, VFIO_IOMMU_UNMAP_DMA, &dma_unmap)\n",
+		    v->cont_fd);
 
-		if (opae_ioctl(v->cont_fd, VFIO_IOMMU_UNMAP_DMA, &dma_unmap) < 0)
-			ERR("ioctl(%d, VFIO_IOMMU_UNMAP_DMA, &dma_unmap)\n",
-			    v->cont_fd);
+	if (!(b->flags & OPAE_VFIO_BUF_PREALLOCATED) &&
+	    munmap(b->buffer_ptr, b->buffer_size) < 0)
+		ERR("munmap(%p, %lu) failed\n",
+		    b->buffer_ptr, b->buffer_size);
 
-		if (!(trash->flags & OPAE_VFIO_BUF_PREALLOCATED) &&
-		    munmap(trash->buffer_ptr, trash->buffer_size) < 0)
-			ERR("munmap(%p, %lu) failed\n",
-			    trash->buffer_ptr, trash->buffer_size);
+	if (mem_alloc_put(&v->iova_alloc, b->buffer_iova))
+		ERR("mem_alloc_put(..., 0x%lx) failed\n",
+		    b->buffer_iova);
 
-		if (mem_alloc_put(&v->iova_alloc, trash->buffer_iova))
-			ERR("mem_alloc_put(..., 0x%lx) failed\n",
-			    trash->buffer_iova);
-
-		opae_free(trash);
-	}
+	opae_free(b);
 }
 
 #ifndef MAP_HUGETLB
@@ -779,6 +772,7 @@ int opae_vfio_buffer_allocate_ex(struct opae_vfio *v,
 				 int flags)
 {
 	struct opae_vfio_buffer *node = NULL;
+	int res = 0;
 
 	if (!v || !size) {
 		ERR("NULL param\n");
@@ -806,13 +800,41 @@ int opae_vfio_buffer_allocate_ex(struct opae_vfio *v,
 		return 4;
 	}
 
-	node->next = v->cont_buffers;
-	v->cont_buffers = node;
+	if (opae_hash_map_add(&v->cont_buffers, *buf, node)) {
+		ERR("opae_hash_map_add() failed\n");
+		res = 5;
+	}
 
 	if (pthread_mutex_unlock(&v->lock))
 		ERR("pthread_mutex_unlock() failed\n");
 
-	return 0;
+	return res;
+}
+
+struct opae_vfio_buffer *opae_vfio_buffer_info(struct opae_vfio *v,
+                                               uint8_t *vaddr)
+{
+	struct opae_vfio_buffer *binfo = NULL;
+
+	if (!v || !vaddr) {
+		ERR("NULL param\n");
+		return NULL;
+	}
+
+	if (pthread_mutex_lock(&v->lock)) {
+		ERR("pthread_mutex_lock() failed\n");
+		return NULL;
+	}
+
+	if(opae_hash_map_find(&v->cont_buffers,
+			      vaddr,
+			      (void **)&binfo))
+		ERR("opae_vfio_buffer_info() failed for key %p\n", vaddr);
+
+	if (pthread_mutex_unlock(&v->lock))
+		ERR("pthread_mutex_unlock() failed\n");
+
+	return binfo;
 }
 
 int opae_vfio_buffer_allocate(struct opae_vfio *v,
@@ -830,8 +852,6 @@ int opae_vfio_buffer_allocate(struct opae_vfio *v,
 int opae_vfio_buffer_free(struct opae_vfio *v,
 			  uint8_t *buf)
 {
-	struct opae_vfio_buffer *b;
-	struct opae_vfio_buffer *prev = NULL;
 	int res = 0;
 
 	if (!v) {
@@ -844,22 +864,11 @@ int opae_vfio_buffer_free(struct opae_vfio *v,
 		return 2;
 	}
 
-	for (b = v->cont_buffers ; b ; prev = b, b = b->next) {
-		if (b->buffer_ptr == buf) {
-			if (!prev) { // b == v->cont_buffers
-				v->cont_buffers = b->next;
-			} else {
-				prev->next = b->next;
-			}
-			b->next = NULL;
-			opae_vfio_destroy_buffer(v, b);
-			goto out_unlock;
-		}
+	if (opae_hash_map_remove(&v->cont_buffers, buf)) {
+		ERR("hash key %p not found\n", buf);
+		res = 3;
 	}
 
-	res = 3;
-
-out_unlock:
 	if (pthread_mutex_unlock(&v->lock))
 		ERR("pthread_mutex_unlock() failed\n");
 
@@ -1108,6 +1117,17 @@ STATIC char *opae_vfio_group_for(const char *pciaddr)
 	return opae_strdup(path);
 }
 
+STATIC
+void opae_vfio_value_cleanup(void *value, void *context)
+{
+	struct opae_vfio_buffer *b =
+		(struct opae_vfio_buffer *)value;
+	struct opae_vfio *v =
+		(struct opae_vfio *)context;
+
+	opae_vfio_destroy_buffer(v, b);
+}
+
 STATIC int opae_vfio_init(struct opae_vfio *v,
 			  const char *pciaddr,
 			  const char *token)
@@ -1115,6 +1135,7 @@ STATIC int opae_vfio_init(struct opae_vfio *v,
 	int res = 0;
 	pthread_mutexattr_t mattr;
 	int cont_fd;
+	fpga_result result;
 
 	memset(v, 0, sizeof(*v));
 	v->cont_fd = -1;
@@ -1122,6 +1143,19 @@ STATIC int opae_vfio_init(struct opae_vfio *v,
 	v->device.device_fd = -1;
 
 	mem_alloc_init(&v->iova_alloc);
+
+	result = opae_hash_map_init(&v->cont_buffers,
+				    16384, // num_buckets
+				    0,     // hash_seed
+				    opae_u64_key_hash,
+				    opae_u64_key_compare,
+				    NULL,  // key_cleanup
+				    opae_vfio_value_cleanup);
+	if (result) {
+		ERR("opae_hash_map_init()\n");
+		return 11;
+	}
+	v->cont_buffers.cleanup_context = v;
 
 	if (pthread_mutexattr_init(&mattr)) {
 		ERR("pthread_mutexattr_init()\n");

--- a/libraries/libopaevfio/opaevfio.c
+++ b/libraries/libopaevfio/opaevfio.c
@@ -812,7 +812,7 @@ int opae_vfio_buffer_allocate_ex(struct opae_vfio *v,
 }
 
 struct opae_vfio_buffer *opae_vfio_buffer_info(struct opae_vfio *v,
-                                               uint8_t *vaddr)
+					       uint8_t *vaddr)
 {
 	struct opae_vfio_buffer *binfo = NULL;
 
@@ -826,9 +826,9 @@ struct opae_vfio_buffer *opae_vfio_buffer_info(struct opae_vfio *v,
 		return NULL;
 	}
 
-	if(opae_hash_map_find(&v->cont_buffers,
-			      vaddr,
-			      (void **)&binfo))
+	if (opae_hash_map_find(&v->cont_buffers,
+			       vaddr,
+			       (void **)&binfo))
 		ERR("opae_vfio_buffer_info() failed for key %p\n", vaddr);
 
 	if (pthread_mutex_unlock(&v->lock))

--- a/libraries/plugins/vfio/opae_vfio.h
+++ b/libraries/plugins/vfio/opae_vfio.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2020-2021, Intel Corporation
+// Copyright(c) 2020-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -148,7 +148,6 @@ int pci_discover(void);
 int features_discover(void);
 pci_device_t *get_pci_device(char addr[PCIADDR_MAX]);
 void free_device_list(void);
-void free_buffer_list(void);
 vfio_token *get_token(pci_device_t *p, uint32_t region, int type);
 fpga_result get_guid(uint64_t *h, fpga_guid guid);
 #endif

--- a/libraries/plugins/vfio/plugin.c
+++ b/libraries/plugins/vfio/plugin.c
@@ -70,7 +70,6 @@ int __VFIO_API__ vfio_plugin_initialize(void)
 
 int __VFIO_API__ vfio_plugin_finalize(void)
 {
-	free_buffer_list();
 	free_device_list();
 
 	opae_free_libopae_config(opae_v_supported_devices);


### PR DESCRIPTION
Add a hash map implementation to libopaemem. The hash map implementation
is modeled after the implementation found in xfpga, but is a more general
implementation, operating on void pointers instead of buffer structs.

Use the hash map to replace the list-based buffer tracking in
libopaevfio to increase performance.

Removes the linked-list tracking for the buffer info and instead stashes
the pointer to libopaevfio's underlying buffer info struct in the wsid
output parameter. This eliminates a list walk in the buffer alloc/free
paths.