### PR TITLE
userclk: fix return code for error paths

### DIFF
--- a/libraries/plugins/xfpga/usrclk/fpga_user_clk.c
+++ b/libraries/plugins/xfpga/usrclk/fpga_user_clk.c
@@ -557,12 +557,14 @@ fpga_result get_usrclk_uio(const char *sysfs_path,
 
 			ret = opae_uio_open(uio, dfl_dev_str);
 			if (ret) {
+				res = FPGA_EXCEPTION;
 				OPAE_ERR("Failed to open uio");
 				break;
 			}
 
 			ret = opae_uio_region_get(uio, 0, (uint8_t **)uio_ptr, NULL);
 			if (ret) {
+				res = FPGA_EXCEPTION;
 				OPAE_ERR("Failed to get uio region");
 				opae_uio_close(uio);
 				break;


### PR DESCRIPTION
These error paths were previously returning FPGA_OK, which led to a seg fault in one code path. Return FPGA_EXCEPTION so that the buffer pointers in question are not de-referenced.