### PR TITLE
packaging/opae.admin/rpm: fix spec issue

### DIFF
--- a/.github/workflows/ccpp-tests.yml
+++ b/.github/workflows/ccpp-tests.yml
@@ -43,6 +43,8 @@ jobs:
         lang-type: [c, cpp]
     steps:
     - uses: actions/checkout@v3
+    - name: bugfix
+      run: sudo rm /var/cache/debconf/config.dat
     - name: update
       run: sudo apt-get update -y
     - name: upgrade
@@ -58,6 +60,8 @@ jobs:
         build-type: [Debug, Release, RelWithDebInfo]
     steps:
     - uses: actions/checkout@v3
+    - name: bugfix
+      run: sudo rm /var/cache/debconf/config.dat
     - name: update
       run: sudo apt-get update -y
     - name: upgrade
@@ -74,6 +78,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: bugfix
+      run: sudo rm /var/cache/debconf/config.dat
     - name: update
       run: sudo apt-get update -y
     - name: upgrade

--- a/.github/workflows/ccpp-tests.yml
+++ b/.github/workflows/ccpp-tests.yml
@@ -37,7 +37,7 @@ on:
 
 jobs:
   coding-style:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         lang-type: [c, cpp]
@@ -52,7 +52,7 @@ jobs:
     - name: test ${{ matrix.lang-type }}
       run: ${{ github.workspace }}/scripts/test-codingstyle-all.sh ${{ matrix.lang-type }}
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         build-type: [Debug, Release, RelWithDebInfo]
@@ -71,7 +71,7 @@ jobs:
     - name: make ${{ matrix.build-type }}
       run: cd ${{ github.workspace }}/.build && make -j $(nproc)
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - name: update
@@ -90,7 +90,7 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: unittests/coverage.info.cleaned
   build-doc:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - name: update

--- a/.github/workflows/ccpp-tests.yml
+++ b/.github/workflows/ccpp-tests.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: bugfix
-      run: sudo rm /var/cache/debconf/config.dat
+      run: sudo rm -f /var/cache/debconf/config.dat
     - name: update
       run: sudo apt-get update -y
     - name: upgrade
@@ -61,7 +61,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: bugfix
-      run: sudo rm /var/cache/debconf/config.dat
+      run: sudo rm -f /var/cache/debconf/config.dat
     - name: update
       run: sudo apt-get update -y
     - name: upgrade
@@ -79,7 +79,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: bugfix
-      run: sudo rm /var/cache/debconf/config.dat
+      run: sudo rm -f /var/cache/debconf/config.dat
     - name: update
       run: sudo apt-get update -y
     - name: upgrade

--- a/.github/workflows/ccpp-tests.yml
+++ b/.github/workflows/ccpp-tests.yml
@@ -37,7 +37,7 @@ on:
 
 jobs:
   coding-style:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         lang-type: [c, cpp]
@@ -52,7 +52,7 @@ jobs:
     - name: test ${{ matrix.lang-type }}
       run: ${{ github.workspace }}/scripts/test-codingstyle-all.sh ${{ matrix.lang-type }}
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         build-type: [Debug, Release, RelWithDebInfo]
@@ -71,7 +71,7 @@ jobs:
     - name: make ${{ matrix.build-type }}
       run: cd ${{ github.workspace }}/.build && make -j $(nproc)
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: update
@@ -90,7 +90,7 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: unittests/coverage.info.cleaned
   build-doc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: update

--- a/packaging/opae.admin/rpm/opae.admin.spec
+++ b/packaging/opae.admin/rpm/opae.admin.spec
@@ -1,6 +1,6 @@
 %define name opae.admin
-%define version 2.0.0
-%define unmangled_version 2.0.0
+%define version @VERSION@
+%define unmangled_version @VERSION@
 %define release 3
 
 Summary: opae.admin provides Python class for interacting with OPAE kernel drivers


### PR DESCRIPTION
Also updates CI so that ubuntu-latest successfully upgrades. Package grub-efi-amd64-signed was failing to configure during `apt upgrade`.  Had success with a solution proposed online.