### PR TITLE
Gcc 13

### DIFF
--- a/binaries/fpgabist/dma/fpga_dma.cpp
+++ b/binaries/fpgabist/dma/fpga_dma.cpp
@@ -475,8 +475,7 @@ static void *dispatcherWorker(void* dma_handle) {
 
 			// make a note of the first block descriptor
 			// mark it valid only after packing rest of the block
-			if (desc_count == 1)
-				first_sw_desc = sw_desc[desc_count];
+			first_sw_desc = sw_desc[1];
 			is_owned_by_hw = (desc_count == 1)  ? false:true;
 
 			// refer prefetcher spec

--- a/libraries/c++utils/cmd_handler.h
+++ b/libraries/c++utils/cmd_handler.h
@@ -30,6 +30,7 @@
 #include <string>
 #include <iostream>
 #include <fstream>
+#include <cstdint>
 
 namespace intel
 {

--- a/libraries/c++utils/cmd_handler.h
+++ b/libraries/c++utils/cmd_handler.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2017, Intel Corporation
+// Copyright(c) 2017-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
These are a couple of fixes to problems building on the latest fedora rawhide which just upgraded to gcc 13