### PR TITLE
rsu: extend --force to also force disabling AER even DPC is supported

### DIFF
--- a/python/opae.admin/opae/admin/tools/rsu.py
+++ b/python/opae.admin/opae/admin/tools/rsu.py
@@ -161,7 +161,7 @@ def parse_args():
     parser.add_argument('-d', '--debug', action='store_true',
                         help='log debug statements')
     parser.add_argument('--force', action='store_true', default=False,
-                        help='perform operation without disabling AER')
+                        help='perform operation if AER not supported or disable AER even DPC supported')
 
     parser.add_argument('-w', '--wait', nargs='?', type=float, default=10.0, action=WaitAction,
                              help='number of seconds to wait for update to complete')


### PR DESCRIPTION
On some servers e.g. Dell R750 and XR12 even DPC is supported, hardware error occurs and server may crash, when running the rsu command on Arrow Creek or Lightning Creek cards. Disabling AER even DPC is supported can workaround these issues. This extension allows that by using the --force option.

There is an ongoing validation by Dell of the Arrow Creek card. Intel, Dell and Silicom are working together on this. This issue has been investigated for some time without finding the root cause. It would thus be good to have this option as a workaround.