### PR TITLE
hssi/afu_test: refactor timeout mechanism

### DIFF
--- a/libraries/afu-test/afu_test.h
+++ b/libraries/afu-test/afu_test.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2020-2022, Intel Corporation
+// Copyright(c) 2020-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:

--- a/libraries/afu-test/afu_test.h
+++ b/libraries/afu-test/afu_test.h
@@ -113,7 +113,7 @@ class afu; // forward declaration
 class command {
 public:
   typedef std::shared_ptr<command> ptr_t;
-  command(){}
+  command() : running_(true) {}
   virtual ~command(){}
   virtual const char *name() const = 0;
   virtual const char *description() const = 0;
@@ -127,8 +127,11 @@ public:
     return nullptr;
   }
 
-private:
+  bool running() const { return running_; }
+  void stop() { running_ = false; }
 
+private:
+  std::atomic<bool> running_;
 };
 
 #if SPDLOG_VERSION >= 10900
@@ -279,8 +282,11 @@ public:
           return test->run(this, app);
         });
       auto status = f.wait_for(std::chrono::milliseconds(timeout_msec_));
-      if (status == std::future_status::timeout)
+      if (status == std::future_status::timeout) {
+        std::cerr << "Error: test timed out" << std::endl;
+        current_command_->stop();
         throw std::runtime_error("timeout");
+      }
       res = f.get();
     } catch(std::exception &ex) {
       res = exit_codes::exception;

--- a/samples/hssi/hssi.cpp
+++ b/samples/hssi/hssi.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2020-2021, Intel Corporation
+// Copyright(c) 2020-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:

--- a/samples/hssi/hssi.cpp
+++ b/samples/hssi/hssi.cpp
@@ -34,7 +34,7 @@ hssi_afu app;
 
 void sig_handler(int signum)
 {
-  auto c = std::dynamic_pointer_cast<hssi_cmd>(app.current_command());
+  opae::afu_test::command::ptr_t c = app.current_command();
   switch (signum) {
   case SIGINT: // Handling signal interrupt(SIGINT) ctrl+C
     std::cerr << "caught SIGINT" << std::endl;

--- a/samples/hssi/hssi_100g_cmd.h
+++ b/samples/hssi/hssi_100g_cmd.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2020-2022, Intel Corporation
+// Copyright(c) 2020-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:

--- a/samples/hssi/hssi_100g_cmd.h
+++ b/samples/hssi/hssi_100g_cmd.h
@@ -492,7 +492,7 @@ public:
       if (count == 0)  // Added to eliminate infinite loop occured when CSR_TX_COUNT is 0
         break;
 
-      if (!running_) {
+      if (!running()) {
         hafu->mbox_write(CSR_CTRL1, STOP_BITS);
         return test_afu::error;
       }
@@ -562,7 +562,7 @@ public:
           reset_monitor(port_, CURSOR_UP, config_data, hafu);
 
         //Handling CTL+C and CTL+Z
-        if (!running_) {
+        if (!running()) {
           quit_monitor(port_size, CURSOR_DOWN, hafu);
           return test_afu::error;
         }

--- a/samples/hssi/hssi_10g_cmd.h
+++ b/samples/hssi/hssi_10g_cmd.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2020-2021, Intel Corporation
+// Copyright(c) 2020-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:

--- a/samples/hssi/hssi_10g_cmd.h
+++ b/samples/hssi/hssi_10g_cmd.h
@@ -199,7 +199,7 @@ public:
 
         std::cout << "HE loopback enabled. Use Ctrl+C to exit." << std::endl;
 
-        while (running_) {
+        while (running()) {
             std::this_thread::sleep_for(std::chrono::milliseconds(1000));
         }
 
@@ -234,7 +234,7 @@ public:
     {
       count = hafu->mbox_read(CSR_PACKET_TX_COUNT);
   
-      if (!running_) {
+      if (!running()) {
         hafu->mbox_write(CSR_STOP, 1);
         return test_afu::error;
       }

--- a/samples/hssi/hssi_cmd.h
+++ b/samples/hssi/hssi_cmd.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2020-2021, Intel Corporation
+// Copyright(c) 2020-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:

--- a/samples/hssi/hssi_cmd.h
+++ b/samples/hssi/hssi_cmd.h
@@ -51,9 +51,7 @@ namespace fpga = opae::fpga::types;
 class hssi_cmd : public test_command
 {
 public:
-  hssi_cmd()
-  : running_(true)
-  {}
+  hssi_cmd() {}
 
   double clock_freq_for(test_afu *afu) const
   {
@@ -173,11 +171,4 @@ public:
     return ss.str();
   }
 
-  void stop()
-  {
-    running_ = false;
-  }
-
-protected:
-  bool running_;
 };


### PR DESCRIPTION
Refactor the timeout mechanism, placing the running_ flag in the afu_test::command class, so that afu_test::afu can stop an in- progress command on timeout. Remove the old mechanism from the hssi_cmd class.