### PR TITLE
fix opaevfiotest Segmentation fault

### DIFF
--- a/libraries/libopaevfio/opaevfiotest.c
+++ b/libraries/libopaevfio/opaevfiotest.c
@@ -47,8 +47,11 @@ void print_dfhs(struct opae_vfio *v)
 	struct fme_dfh *mmio = NULL;
 	uint8_t *p = NULL;
 
-	if (opae_vfio_region_get(v, 0, (uint8_t **)&mmio, NULL))
+	if (opae_vfio_region_get(v, 0, (uint8_t **)&mmio, NULL)) {
+		printf("error getting BAR 0\n");
 		return;
+	}
+
 
 	printf("FME\n"
 	       "dfh:         0x%016lx\n"
@@ -58,8 +61,11 @@ void print_dfhs(struct opae_vfio *v)
 	       mmio->fme_version, mmio->afu_id_low,
 	       mmio->afu_id_high, mmio->next_afu);
 
-	if (opae_vfio_region_get(v, 2, (uint8_t **)&mmio, NULL))
+	if (opae_vfio_region_get(v, 2, (uint8_t **)&mmio, NULL)) {
+		printf("error getting BAR 2\n");
 		return;
+	}
+
 
 	printf("Port\n"
 	       "dfh:         0x%016lx\n"


### PR DESCRIPTION
Segmentation fault1: opaevfiotest  0000:3b:00.1 dfh
PF1 and PF2 doesn’t support Bar 2 , opae_vfio_region_get() function ignores function return code  causes Segmentation fault
Fix: print_dfh() function exits gracefully  if opae_vfio_region_get() fails.

Segmentation fault2: opaevfiotest  0000:3b:00.0 nlb0
opae_vfio_region_get() and opae_vfio_buffer_allocate() functions ignores function return code  causes Segmentation fault
Fix: nlb0 () function exits gracefully   if opae_vfio_region_get() and opae_vfio_buffer_allocate() fails.
