### PR TITLE
(Cherry-pick) rename C6100 platform name to Intel IPU Platform F2000X-PL (#2910)

### DIFF
--- a/binaries/opae.io/opae/io/config.py
+++ b/binaries/opae.io/opae/io/config.py
@@ -98,10 +98,10 @@ DEFAULT_OPAE_IO_CONFIG = {
     'platform': 'Intel Acceleration Development Platform N6001'
   },
   (0x8086, 0xbcce, 0x8086, 0x17d4): {
-    'platform': 'Intel Acceleration Development Platform C6100'
+    'platform': 'Intel IPU Platform F2000X-PL'
   },
   (0x8086, 0xbccf, 0x8086, 0x17d4): {
-    'platform': 'Intel Acceleration Development Platform C6100'
+    'platform': 'Intel IPU Platform F2000X-PL'
   },
   (0x8086, 0xaf00, 0x8086, 0): {
     'platform': 'Intel Open FPGA Stack Platform'

--- a/libraries/libopae-c/cfg-file.c
+++ b/libraries/libopae-c/cfg-file.c
@@ -416,7 +416,7 @@ STATIC fpgainfo_config_data default_fpgainfo_config_table[] = {
 	"Intel Acceleration Development Platform N6001" },
 
 	{ 0x8086, 0xbcce, 0x8086, 0x17d4, 0x12, "libboard_c6100.so", NULL,
-	"Intel Acceleration Development Platform C6100" },
+	"Intel IPU Platform F2000X-PL" },
 
 	{ 0,      0, 0, 0, -1,         NULL, NULL, "" }
 };

--- a/opae.cfg
+++ b/opae.cfg
@@ -538,7 +538,7 @@
 
     "c6100": {
       "enabled": true,
-      "platform": "Intel Acceleration Development Platform C6100",
+      "platform": "Intel IPU Platform F2000X-PL",
 
       "devices": [
         { "name": "c6100_pf", "id": [ "0x8086", "0xbcce", "0x8086", "0x17d4" ] },

--- a/python/opae.admin/opae/admin/config.py
+++ b/python/opae.admin/opae/admin/config.py
@@ -137,10 +137,10 @@ DEFAULT_FPGAREG_CONFIG = {
     'platform': 'Intel Acceleration Development Platform N6001'
   },
   (0x8086, 0xbcce, 0x8086, 0x17d4): {
-    'platform': 'Intel Acceleration Development Platform C6100'
+    'platform': 'Intel IPU Platform F2000X-PL'
   },
   (0x8086, 0xbccf, 0x8086, 0x17d4): {
-    'platform': 'Intel Acceleration Development Platform C6100'
+    'platform': 'Intel IPU Platform F2000X-PL'
   },
   (0x8086, 0xaf00, 0x8086, 0): {
     'platform': 'Intel Open FPGA Stack Platform'

--- a/tests/opae.admin/test_config.py
+++ b/tests/opae.admin/test_config.py
@@ -186,7 +186,7 @@ TEST_CONFIG = '''{
 
     "c6100": {
       "enabled": true,
-      "platform": "Intel Acceleration Development Platform C6100",
+      "platform": "Intel IPU Platform F2000X-PL",
   
       "devices": [
         { "name": "c6100_pf", "id": [ "0x8086", "0xbcce", "0x8086", "0x17d4" ] },
@@ -472,8 +472,8 @@ class TestEnv(unittest.TestCase):
         assert Config.fpgareg_platform_for(0x8086, 0xbccf, 0x8086, 0x1770) == 'Intel Acceleration Development Platform N6000'
         assert Config.fpgareg_platform_for(0x8086, 0xbcce, 0x8086, 0x1771) == 'Intel Acceleration Development Platform N6001'
         assert Config.fpgareg_platform_for(0x8086, 0xbccf, 0x8086, 0x1771) == 'Intel Acceleration Development Platform N6001'
-        assert Config.fpgareg_platform_for(0x8086, 0xbcce, 0x8086, 0x17d4) == 'Intel Acceleration Development Platform C6100'
-        assert Config.fpgareg_platform_for(0x8086, 0xbccf, 0x8086, 0x17d4) == 'Intel Acceleration Development Platform C6100'
+        assert Config.fpgareg_platform_for(0x8086, 0xbcce, 0x8086, 0x17d4) == 'Intel IPU Platform F2000X-PL'
+        assert Config.fpgareg_platform_for(0x8086, 0xbccf, 0x8086, 0x17d4) == 'Intel IPU Platform F2000X-PL'
         assert Config.fpgareg_platform_for(0x8086, 0xaf00, 0x8086, 0) == 'Intel Open FPGA Stack Platform'
         assert Config.fpgareg_platform_for(0x8086, 0xaf01, 0x8086, 0) == 'Intel Open FPGA Stack Platform'
         assert Config.fpgareg_platform_for(0x8086, 0xbcce, 0x8086, 0) == 'Intel Open FPGA Stack Platform'

--- a/tests/opae.io/test_config.py
+++ b/tests/opae.io/test_config.py
@@ -175,7 +175,7 @@ TEST_CONFIG = '''{
 
     "c6100": {
       "enabled": true,
-      "platform": "Intel Acceleration Development Platform C6100",
+      "platform": "Intel IPU Platform F2000X-PL",
 
       "devices": [
         { "name": "c6100_pf", "id": [ "0x8086", "0xbcce", "0x8086", "0x17d4" ] },
@@ -337,8 +337,8 @@ class TestEnv(unittest.TestCase):
         assert Config.opae_io_platform_for(0x8086, 0xbccf, 0x8086, 0x1770) == 'Intel Acceleration Development Platform N6000'
         assert Config.opae_io_platform_for(0x8086, 0xbcce, 0x8086, 0x1771) == 'Intel Acceleration Development Platform N6001'
         assert Config.opae_io_platform_for(0x8086, 0xbccf, 0x8086, 0x1771) == 'Intel Acceleration Development Platform N6001'
-        assert Config.opae_io_platform_for(0x8086, 0xbcce, 0x8086, 0x17d4) == 'Intel Acceleration Development Platform C6100'
-        assert Config.opae_io_platform_for(0x8086, 0xbccf, 0x8086, 0x17d4) == 'Intel Acceleration Development Platform C6100'
+        assert Config.opae_io_platform_for(0x8086, 0xbcce, 0x8086, 0x17d4) == 'Intel IPU Platform F2000X-PL'
+        assert Config.opae_io_platform_for(0x8086, 0xbccf, 0x8086, 0x17d4) == 'Intel IPU Platform F2000X-PL'
         assert Config.opae_io_platform_for(0x8086, 0xaf00, 0x8086, 0) == 'Intel Open FPGA Stack Platform'
         assert Config.opae_io_platform_for(0x8086, 0xaf01, 0x8086, 0) == 'Intel Open FPGA Stack Platform'
         assert Config.opae_io_platform_for(0x8086, 0xbcce, 0x8086, 0) == 'Intel Open FPGA Stack Platform'


### PR DESCRIPTION
* rename C6100 platform name to Intel IPU Platform F2000X-PL

rename C6100 platform name to  in opae.cfg