### PR TITLE
(Cherry-pick) add QSFP cable status to fpgainfo phy (#2916)

### DIFF
--- a/libraries/libboard/board_c6100/board_c6100.c
+++ b/libraries/libboard/board_c6100/board_c6100.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2022, Intel Corporation
+// Copyright(c) 2022-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -422,6 +422,11 @@ fpga_result print_phy_info(fpga_token token)
 	struct opae_uio uio;
 	char feature_dev[SYSFS_PATH_MAX] = { 0 };
 	uint8_t *mmap_ptr = NULL;
+
+	res = qsfp_cable_status(token);
+	if (res != FPGA_OK) {
+		OPAE_MSG("Failed to find QSFP cable info");
+	}
 
 	res = find_dev_feature(token, HSSI_FEATURE_ID, feature_dev);
 	if (res != FPGA_OK) {

--- a/libraries/libboard/board_common/board_common.h
+++ b/libraries/libboard/board_common/board_common.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2019-2022, Intel Corporation
+// Copyright(c) 2019-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -186,6 +186,16 @@ fpga_result reformat_bom_info(
 	char *const bom_info,
 	const size_t len,
 	const size_t max_result_len);
+
+/**
+* prints QSFP cable status.
+*
+* @param[in] token           fpga_token object for device (FPGA_DEVICE type)
+* @returns FPGA_OK on success.
+* FPGA_EXCEPTION if invalid sysfs path
+*/
+fpga_result qsfp_cable_status(const fpga_token token);
+
 
 #ifdef __cplusplus
 }

--- a/libraries/libboard/board_n6000/board_n6000.c
+++ b/libraries/libboard/board_n6000/board_n6000.c
@@ -1,4 +1,4 @@
-// Copyright(c) 2021-2022, Intel Corporation
+// Copyright(c) 2021-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -509,6 +509,11 @@ fpga_result print_phy_info(fpga_token token)
 	struct opae_uio uio;
 	char feature_dev[SYSFS_PATH_MAX] = { 0 };
 	uint8_t *mmap_ptr = NULL;
+
+	res = qsfp_cable_status(token);
+	if (res != FPGA_OK) {
+		OPAE_MSG("Failed to find QSFP cable info");
+	}
 
 	res = find_dev_feature(token, HSSI_FEATURE_ID, feature_dev);
 	if (res != FPGA_OK) {


### PR DESCRIPTION
* add QSFP cable status to fpgainfo phy

fpgainfo phy reads QSFP cable  status and prints connected or not connected

QSFP0                            : Not Connected
QSFP1                            : Not Connected



* fix qsfp not supported case



---------