### PR TITLE
fpgainfo bmc: Fix when having both N601x and N501x card, sensors from…

### DIFF
--- a/libraries/plugins/xfpga/metrics/metrics_max10.c
+++ b/libraries/plugins/xfpga/metrics/metrics_max10.c
@@ -146,10 +146,11 @@ out:
 
 
 
-fpga_result  dfl_enum_max10_metrics_info(struct _fpga_handle *_handle,
+fpga_result  dfl_enum_max10_metrics_info_pattern(struct _fpga_handle *_handle,
 	fpga_metric_vector *vector,
 	uint64_t *metric_num,
-	enum fpga_hw_type  hw_type)
+	enum fpga_hw_type  hw_type,
+	const char *glob_pattern)
 {
 	fpga_result result                         = FPGA_OK;
 	struct _fpga_token *_token                 = NULL;
@@ -184,7 +185,7 @@ fpga_result  dfl_enum_max10_metrics_info(struct _fpga_handle *_handle,
 
 	// metrics group
 	if (snprintf(glob_path, sizeof(glob_path),
-		"%s/%s", _token->sysfspath, DFL_MAX10_SYSFS_PATH) < 0) {
+		"%s/%s", _token->sysfspath, glob_pattern) < 0) {
 		OPAE_ERR("snprintf failed");
 		return FPGA_EXCEPTION;
 	}
@@ -356,6 +357,15 @@ out:
 	return result;
 }
 
+
+
+fpga_result  dfl_enum_max10_metrics_info(struct _fpga_handle *_handle,
+	fpga_metric_vector *vector,
+	uint64_t *metric_num,
+	enum fpga_hw_type  hw_type)
+{
+	return dfl_enum_max10_metrics_info_pattern(_handle, vector, metric_num, hw_type, DFL_MAX10_SYSFS_PATH);
+}
 
 fpga_result read_max10_value(struct _fpga_enum_metric *_fpga_enum_metric,
 					double *dvalue)

--- a/libraries/plugins/xfpga/metrics/metrics_max10.h
+++ b/libraries/plugins/xfpga/metrics/metrics_max10.h
@@ -34,6 +34,7 @@
 
 
 #define DFL_MAX10_SYSFS_PATH                    "*dfl_*/*/**/*hwmon*/hwmon/hwmon*/"
+#define DFL_MAX10_SYSFS_PATH_SPI_MASTER         "*dfl_*/spi_master/**/*hwmon*/hwmon/hwmon*/"
 #define DFL_MAX10_SYSFS_LABEL                   "*_label"
 #define DFL_TEMPERATURE                         "temp"
 #define DFL_VOLTAGE                             "in"
@@ -52,4 +53,10 @@ fpga_result  dfl_enum_max10_metrics_info(struct _fpga_handle *_handle,
 	fpga_metric_vector *vector,
 	uint64_t *metric_num,
 	enum fpga_hw_type  hw_type);
+
+fpga_result  dfl_enum_max10_metrics_info_pattern(struct _fpga_handle *_handle,
+	fpga_metric_vector *vector,
+	uint64_t *metric_num,
+	enum fpga_hw_type  hw_type,
+	const char *glob_pattern);
 #endif // __FPGA_METRICS_MAX10_H__

--- a/libraries/plugins/xfpga/metrics/metrics_utils.c
+++ b/libraries/plugins/xfpga/metrics/metrics_utils.c
@@ -581,14 +581,26 @@ fpga_result enum_fpga_metrics(fpga_handle handle)
 
 		// DCP VC DC
 		case FPGA_HW_DCP_N3000:
-		case FPGA_HW_DCP_D5005:
-		case FPGA_HW_DCP_N5010: {
+		case FPGA_HW_DCP_D5005: {
 
 			// Max10 Power & Thermal
 			result = dfl_enum_max10_metrics_info(_handle,
 					&(_handle->fpga_enum_metric_vector),
 					&metric_num,
 					hw_type);
+					if (result != FPGA_OK) {
+						OPAE_ERR("Failed to Enum Power and Thermal metrics.");
+					}
+		}
+		break;
+		case FPGA_HW_DCP_N5010: {
+
+			// Max10 Power & Thermal
+			result = dfl_enum_max10_metrics_info_pattern(_handle,
+					&(_handle->fpga_enum_metric_vector),
+					&metric_num,
+					hw_type,
+					DFL_MAX10_SYSFS_PATH_SPI_MASTER);
 					if (result != FPGA_OK) {
 						OPAE_ERR("Failed to Enum Power and Thermal metrics.");
 					}


### PR DESCRIPTION
… N601x is shown for N501x card

Since N60xx has a 3 directories shorter path to "/*hwmon*/", using the symbolic link in "subsystem" gives a path to N60xx hwmon with same depth as N50xx hwmon.

find_glob_path() finds the N60xx directory instead of the N50xx. Using a more specific glob pattern for FPGA_HW_DCP_N5010, prevents this.

I am using a branch in my fork since I could not push a feature branch directly to OFS/opae-sdk.