### PR TITLE
Fix GitHub Actions build-debs and build-rpms

### DIFF
--- a/.github/workflows/build-debs.yml
+++ b/.github/workflows/build-debs.yml
@@ -33,5 +33,5 @@ jobs:
         with:
           name: OPAE-${{ matrix.distro }}
           path:
-            ${{ matrix.distro }}/opae-sdk/packaging/opae/deb/*.deb
+            ${{ github.workspace }}/packaging/opae/deb/*.deb
 

--- a/.github/workflows/build-rpms.yml
+++ b/.github/workflows/build-rpms.yml
@@ -33,5 +33,5 @@ jobs:
         with:
           name: OPAE-${{ matrix.distro }}
           path:
-            ${{ matrix.distro }}/opae-sdk/packaging/opae/rpm/*.rpm
+            ${{ github.workspace }}/packaging/opae/rpm/*.rpm
 


### PR DESCRIPTION
The current build-debs and build-rpms workflows do not upload the built artifacts, because they are trying to upload from the wrong directory.

This change corrects the directory, so the artifacts are uploaded.