### PR TITLE
(Cherry-pick) Get opae.io out of a pickle

### DIFF
--- a/binaries/opae.io/opae/io/utils.py
+++ b/binaries/opae.io/opae/io/utils.py
@@ -96,7 +96,11 @@ def bind_driver(driver, pci_addr):
 def get_dev_dict(file_name):
     if os.path.isfile(file_name):
         with open(file_name, 'rb') as inf:
-            dev_dict = pickle.load(inf)
+            try:
+                dev_dict = pickle.load(inf)
+            except EOFError:
+                LOG.warn('Overwriting corrupted pickle file {}'.format(file_name))
+                dev_dict = dict()
             return dev_dict
 
 


### PR DESCRIPTION
If the pickle file becomes corrupt, for example by being empty, opae.io init failed silently and printed a prompt without opening the device. The update gives up on the unreadable state and overwrites the pickle file.