### PR TITLE
add new PCIe Persistent error logging to fpgainfo events (

### DIFF
--- a/libraries/libboard/board_c6100/board_event_log.c
+++ b/libraries/libboard/board_c6100/board_event_log.c
@@ -48,7 +48,8 @@ enum bel_magic {
 	BEL_POWER_OFF_STATUS    = 0x53696C34,
 	BEL_SENSORS_STATE       = 0x53696C56,
 	BEL_SENSORS_STATUS      = 0x53696C78,
-	BEL_PCI_ERROR_STATUS    = 0x53696C9A
+	BEL_PCI_ERROR_STATUS    = 0x53696C9A,
+	BEL_PCI_V1_ERROR_STATUS = 0x53696D12
 };
 
 enum bel_power_regulator {
@@ -709,6 +710,124 @@ void bel_print_pci_error_status(struct bel_pci_error_status *status, bool print_
 
 }
 
+void bel_print_pci_v1_error_status(struct bel_pcie_v1_error_status *status, bool print_bits)
+{
+
+	if (status->header.magic != BEL_PCI_V1_ERROR_STATUS)
+		return;
+
+	bel_print_header("PCI Error Status Time", &status->header);
+
+	// PCIe Link Status
+	bel_print_value("PCIe Link Status", status->pcie_link_status);
+	if (print_bits) {
+		bel_print_field("Current Link Speed", status->pcie_link_status, 0, 3);
+		bel_print_field("Negotiated Link Speed", status->pcie_link_status, 4, 9);
+		bel_print_bit("Link Training ", status->pcie_link_status, 11);
+		bel_print_bit("Slot Clock Configuration", status->pcie_link_status, 12);
+		bel_print_bit("Data link layer link active", status->pcie_link_status, 13);
+		bel_print_bit("Link Bandwidth Management Status", status->pcie_link_status, 14);
+		bel_print_bit("Link Autonomous Management Status", status->pcie_link_status, 15);
+	}
+
+	// PCIe Uncorrectable Error
+	bel_print_value("PCIe Uncorrectable Error", status->pcie_uncorr_err);
+	if (print_bits) {
+		bel_print_bit("Data Link Protocol error Status", status->pcie_uncorr_err, 4);
+		bel_print_bit("Surprise down error Status", status->pcie_uncorr_err, 5);
+		bel_print_bit("Poisoned TLP received", status->pcie_uncorr_err, 12);
+		bel_print_bit("Flow Control Protocol Errors Status", status->pcie_uncorr_err, 13);
+		bel_print_bit("Completion Timeout Status", status->pcie_uncorr_err, 14);
+		bel_print_bit("Completer Abort error Status", status->pcie_uncorr_err, 15);
+		bel_print_bit("Unexpected Completion Status", status->pcie_uncorr_err, 16);
+		bel_print_bit("Receiver Overflow Status", status->pcie_uncorr_err, 17);
+		bel_print_bit("Malformed TLP Status", status->pcie_uncorr_err, 18);
+		bel_print_bit("ECRC Error Status", status->pcie_uncorr_err, 19);
+		bel_print_bit("Unsupported Request Error Status", status->pcie_uncorr_err, 20);
+		bel_print_bit("ACS Violation Status", status->pcie_uncorr_err, 21);
+		bel_print_bit("Uncorrectable Internal Error Status", status->pcie_uncorr_err, 22);
+		bel_print_bit("MC Blocked TLP Status", status->pcie_uncorr_err, 23);
+		bel_print_bit("AtomicOp Egress Blocked Status", status->pcie_uncorr_err, 24);
+		bel_print_bit("TLP Prefix Blocked Status", status->pcie_uncorr_err, 25);
+		bel_print_bit("Poisoned TLP Egress Blocked Status", status->pcie_uncorr_err, 26);
+	}
+
+	// PCIe Uncorrectable Err Mask
+	bel_print_value("PCIe Uncorrectable Err Mask", status->pcie_uncorr_err_mask);
+	if (print_bits) {
+		bel_print_bit("Data Link Protocol error", status->pcie_uncorr_err, 4);
+		bel_print_bit("Surprise down error", status->pcie_uncorr_err, 5);
+		bel_print_bit("Poisoned TLP received", status->pcie_uncorr_err, 12);
+		bel_print_bit("Flow Control Protocol Errors", status->pcie_uncorr_err, 13);
+		bel_print_bit("Completion Timeout", status->pcie_uncorr_err, 14);
+		bel_print_bit("Completer Abort error", status->pcie_uncorr_err, 15);
+		bel_print_bit("Unexpected Completion", status->pcie_uncorr_err, 16);
+		bel_print_bit("Receiver Overflow", status->pcie_uncorr_err, 17);
+		bel_print_bit("Malformed TLP", status->pcie_uncorr_err, 18);
+		bel_print_bit("ECRC Error", status->pcie_uncorr_err, 19);
+		bel_print_bit("Unsupported Request Error", status->pcie_uncorr_err, 20);
+		bel_print_bit("ACS Violation", status->pcie_uncorr_err, 21);
+		bel_print_bit("Uncorrectable Internal Error", status->pcie_uncorr_err, 22);
+		bel_print_bit("MC Blocked TLP", status->pcie_uncorr_err, 23);
+		bel_print_bit("AtomicOp Egress Blocked", status->pcie_uncorr_err, 24);
+		bel_print_bit("TLP Prefix Blocked", status->pcie_uncorr_err, 25);
+		bel_print_bit("Poisoned TLP Egress Blocked", status->pcie_uncorr_err, 26);
+	}
+
+	//PCIE Uncorrectable Err Severity
+	bel_print_value("PCIe Uncorrectable Err Severity", status->pcie_uncorr_err_severity);
+	if (print_bits) {
+		bel_print_bit("Data Link Protocol error", status->pcie_uncorr_err_severity, 4);
+		bel_print_bit("Surprise Down Error", status->pcie_uncorr_err_severity, 5);
+		bel_print_bit("Poisoned TLP", status->pcie_uncorr_err_severity, 12);
+		bel_print_bit("Flow Control protocol error", status->pcie_uncorr_err_severity, 13);
+		bel_print_bit("Completion Timeout", status->pcie_uncorr_err_severity, 14);
+		bel_print_bit("Completer Abort (CA) was transmitted", status->pcie_uncorr_err_severity, 15);
+		bel_print_bit("Unexpected Completion was received", status->pcie_uncorr_err_severity, 16);
+		bel_print_bit("Receiver Overflow", status->pcie_uncorr_err_severity, 17);
+		bel_print_bit("Malformed TLP Received", status->pcie_uncorr_err_severity, 18);
+		bel_print_bit("ECRC Error Detected", status->pcie_uncorr_err_severity, 19);
+		bel_print_bit("Unsupported Request Received", status->pcie_uncorr_err_severity, 20);
+	}
+
+	//PCIE Correctable Err Status
+	bel_print_value("PCIe Correctable Err Status", status->pcie_corr_err_status);
+	if (print_bits) {
+		bel_print_bit("Receiver Error status", status->pcie_corr_err_status, 0);
+		bel_print_bit("Bad TLP status", status->pcie_corr_err_status, 6);
+		bel_print_bit("Bad DLLP status", status->pcie_corr_err_status, 7);
+		bel_print_bit("Replay Number Rollover status", status->pcie_corr_err_status, 8);
+		bel_print_bit("Replay timer Timeout status", status->pcie_corr_err_status, 12);
+		bel_print_bit("Advisory Non-Fatal Error status", status->pcie_corr_err_status, 13);
+		bel_print_bit("Corrected internal error status", status->pcie_corr_err_status, 14);
+	}
+
+	//PCIE Correctable Err Mask
+	bel_print_value("PCIe Correctable Err Mask", status->pcie_corr_err_mask);
+	if (print_bits) {
+		bel_print_bit("Receiver Error", status->pcie_corr_err_status, 0);
+		bel_print_bit("Bad TLP", status->pcie_corr_err_status, 6);
+		bel_print_bit("Bad DLLP", status->pcie_corr_err_status, 7);
+		bel_print_bit("Replay Number Rollover", status->pcie_corr_err_status, 8);
+		bel_print_bit("Replay timer Timeout", status->pcie_corr_err_status, 12);
+		bel_print_bit("Advisory Non-Fatal Error", status->pcie_corr_err_status, 13);
+		bel_print_bit("Corrected internal error", status->pcie_corr_err_status, 14);
+	}
+
+	//PCIE Cap And Ctrl
+	bel_print_value("PCIe Cap And Ctrl", status->pcie_cap_ctrl);
+
+	//PCIE Header Log DW 1
+	bel_print_value("PCIE Header Log DW1", status->pcie_header_log1);
+	//PCIE Header Log DW 2
+	bel_print_value("PCIE Header Log DW2", status->pcie_header_log1);
+	//PCIE Header Log DW 3
+	bel_print_value("PCIE Header Log DW3", status->pcie_header_log1);
+	//PCIE Header Log DW 4
+	bel_print_value("PCIE Header Log DW4", status->pcie_header_log1);
+
+}
+
 uint32_t bel_ptr_count(void)
 {
 	return BEL_BLOCK_COUNT;
@@ -775,6 +894,7 @@ void bel_print(struct bel_event *event, bool print_sensors, bool print_bits)
 		bel_print_sensors_state(&event->sensors_state);
 		bel_print_sensors_status(&event->sensors_status);
 	}
+	bel_print_pci_v1_error_status(&event->pcie_v1_error_status, print_bits);
 
 }
 

--- a/libraries/libboard/board_c6100/board_event_log.h
+++ b/libraries/libboard/board_c6100/board_event_log.h
@@ -124,6 +124,21 @@ struct bel_pci_error_status {
 	uint32_t reserved[7];
 } __attribute__((__packed__));
 
+struct bel_pcie_v1_error_status {
+	struct bel_header header;
+	uint32_t pcie_link_status;
+	uint32_t pcie_uncorr_err;
+	uint32_t pcie_uncorr_err_mask;
+	uint32_t pcie_uncorr_err_severity;
+	uint32_t pcie_corr_err_status;
+	uint32_t pcie_corr_err_mask;
+	uint32_t pcie_cap_ctrl;
+	uint32_t pcie_header_log1;
+	uint32_t pcie_header_log2;
+	uint32_t pcie_header_log3;
+	uint32_t pcie_header_log4;
+} __attribute__((__packed__)) ;
+
 struct bel_event {
 	union {
 		struct {
@@ -135,6 +150,7 @@ struct bel_event {
 			struct bel_power_off_status power_off_status;
 			struct bel_sensors_state sensors_state;
 			struct bel_sensors_status sensors_status;
+			struct bel_pcie_v1_error_status pcie_v1_error_status;
 		};
 		uint32_t data[1];
 	};

--- a/tests/board/test_board_c6100.cpp
+++ b/tests/board/test_board_c6100.cpp
@@ -144,6 +144,7 @@ void bel_print_power_on_status(struct bel_power_on_status* status,
                             struct bel_timeof_day* timeof_day,
                             bool print_bits);
 void bel_print(struct bel_event *event, bool print_sensors, bool print_bits);
+void bel_print_pci_v1_error_status(struct bel_pcie_v1_error_status* status, bool print_bits);
 }
 
 // test DFL sysfs attributes
@@ -407,6 +408,11 @@ TEST_P(board_dfl_c6100_c_p, board_c6100_13) {
 
   struct bel_event event;
   EXPECT_NO_THROW(bel_print(&event, true, true));
+
+  struct bel_pcie_v1_error_status pcie_v1_err;
+  memset(&pcie_v1_err, 0x0, sizeof(pcie_v1_err));
+  pcie_v1_err.header.magic = 0x53696D12;
+  EXPECT_NO_THROW(bel_print_pci_v1_error_status(&pcie_v1_err,true));
 }
 
 /**


### PR DESCRIPTION
support  new PCIe Persistent error to fpgainfo events for N6000 and enabled in BMC version 11.5 version

0x0924 Magic Num- PCIE Errors (Updated) 0x53696D12 in process context in main cycle PCIe error log 0x0928 Time stamp low Low timestamp 1
0x092C Time stamp high High timestamp 2
0x0930 PCIe Link Status PCIE Link Status
0x0934 PCIE Uncorrectable Err Status PCIE Uncorrectable Err Status 0x093C PCIE Uncorrectable Err Mask PCIE Uncorrectable Err Mask 0x0940 PCIE Uncorrectable Err Severity PCIE Uncorrectable Err Severity 0x0944 PCIE Correctable Err Status PCIE Correctable Err Status 0x0948 PCIE Correctable Err Mask PCIE Correctable Err Mask 0x094C PCIE Cap And Ctrl PCIE Cap And Ctrl
0x0950 PCIE Header Log DW 1 PCIE Header Log DW 1
0x0954 PCIE Header Log DW 2 PCIE Header Log DW 2
0x0958 PCIE Header Log DW 3 PCIE Header Log DW 3