### PR TITLE
ci: add spdlog and cli11 to ubuntu22.04

### DIFF
--- a/docker/ubuntu22/Dockerfile
+++ b/docker/ubuntu22/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3 python3-pip python3-dev git gcc g++ make cmake doxygen pandoc uuid-dev libjson-c-dev libhwloc-dev libtbb-dev libedit-dev libudev-dev bsdmainutils devscripts debhelper dh-python
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3 python3-pip python3-dev git gcc g++ make cmake doxygen pandoc uuid-dev libjson-c-dev libhwloc-dev libtbb-dev libedit-dev libspdlog-dev libcli11-dev libudev-dev bsdmainutils devscripts debhelper dh-python
 RUN python3 -m pip install setuptools --upgrade --prefix=/usr
 RUN python3 -m pip install pyyaml jsonschema pybind11
 WORKDIR /root

--- a/docker/ubuntu22/Dockerfile
+++ b/docker/ubuntu22/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3 python3-pip python3-dev git gcc g++ make cmake doxygen pandoc uuid-dev libjson-c-dev libhwloc-dev libtbb-dev libedit-dev libspdlog-dev libcli11-dev libudev-dev bsdmainutils devscripts debhelper dh-python
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3 python3-pip python3-dev python3-pybind11 git gcc g++ make cmake doxygen pandoc uuid-dev libjson-c-dev libhwloc-dev libtbb-dev libedit-dev libspdlog-dev libcli11-dev libudev-dev bsdmainutils devscripts debhelper dh-python doxygen
 RUN python3 -m pip install setuptools --upgrade --prefix=/usr
 RUN python3 -m pip install pyyaml jsonschema pybind11
 WORKDIR /root

--- a/libraries/libboard/board_n6000/board_event_log.h
+++ b/libraries/libboard/board_n6000/board_event_log.h
@@ -154,7 +154,16 @@ struct bel_event {
 			struct bel_sensors_status sensors_status;
 			struct bel_pcie_v1_error_status pcie_v1_error_status;
 		};
-		uint32_t data[1];
+		uint32_t data[(sizeof(struct bel_power_on_status) +
+			       sizeof(struct bel_timeof_day) +
+			       sizeof(struct bel_max10_seu) +
+			       sizeof(struct bel_fpga_seu) +
+			       sizeof(struct bel_pci_error_status) +
+			       sizeof(struct bel_power_off_status) +
+			       sizeof(struct bel_sensors_state) +
+			       sizeof(struct bel_sensors_status) +
+			       sizeof(struct bel_pcie_v1_error_status)
+			      )/sizeof(uint32_t)];
 	};
 } __attribute__((__packed__));
 

--- a/libraries/libboard/board_n6000/board_event_log.h
+++ b/libraries/libboard/board_n6000/board_event_log.h
@@ -154,16 +154,7 @@ struct bel_event {
 			struct bel_sensors_status sensors_status;
 			struct bel_pcie_v1_error_status pcie_v1_error_status;
 		};
-		uint32_t data[(sizeof(struct bel_power_on_status) +
-			       sizeof(struct bel_timeof_day) +
-			       sizeof(struct bel_max10_seu) +
-			       sizeof(struct bel_fpga_seu) +
-			       sizeof(struct bel_pci_error_status) +
-			       sizeof(struct bel_power_off_status) +
-			       sizeof(struct bel_sensors_state) +
-			       sizeof(struct bel_sensors_status) +
-			       sizeof(struct bel_pcie_v1_error_status)
-			      )/sizeof(uint32_t)];
+		uint32_t data[];
 	};
 } __attribute__((__packed__));
 

--- a/libraries/libboard/board_n6000/board_event_log.h
+++ b/libraries/libboard/board_n6000/board_event_log.h
@@ -154,7 +154,7 @@ struct bel_event {
 			struct bel_sensors_status sensors_status;
 			struct bel_pcie_v1_error_status pcie_v1_error_status;
 		};
-		uint32_t data[];
+		uint32_t data[1];
 	};
 } __attribute__((__packed__));
 

--- a/scripts/test-codingstyle-all.sh
+++ b/scripts/test-codingstyle-all.sh
@@ -23,13 +23,14 @@ find_c() {
     find "${OPAE_SDK_ROOT}/libraries/libboard" -iname "*.c" -or -iname "*.h"
 }
 
+declare -r CHECKPATCH_HASH='d0f90841cba1931ee8284297deda53f098de5c82'
 check_c () {
     pushd $(dirname $0) >/dev/null
 
     CHECKPATCH=checkpatch.pl
 
     if [ ! -f $CHECKPATCH ]; then
-        wget --no-check-certificate https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl
+        wget --no-check-certificate https://raw.githubusercontent.com/torvalds/linux/${CHECKPATCH_HASH}/scripts/checkpatch.pl
         if [ ! -f $CHECKPATCH ]; then
             echo "Couldn't download checkpatch.pl - please put a copy into the same"
             echo "directory as this script."


### PR DESCRIPTION
These packages are required, but were missing from the Dockerfile for the CI job that builds and tests .deb packages.