### PR TITLE
multi-channel mem_tg test 

### DIFF
--- a/samples/mem_tg/mem_tg.h
+++ b/samples/mem_tg/mem_tg.h
@@ -25,6 +25,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 #include <opae/cxx/core/token.h>
+#include <iostream>
+#include <vector>
 
 #include "afu_test.h"
 
@@ -208,7 +210,7 @@ public:
 
 public:
   uint32_t count_;
-  uint32_t mem_ch_;
+  std::vector<std::string> mem_ch_;
   uint32_t loop_;
   uint32_t wcnt_;
   uint32_t rcnt_;
@@ -232,6 +234,20 @@ public:
   token::ptr_t get_token()
   {
     return handle_->get_token();
+  }
+
+  mem_tg* duplicate() const {
+    mem_tg *duplicate = new mem_tg;
+
+    duplicate->count_       = this->count_;
+    duplicate->loop_        = this->loop_;
+    duplicate->wcnt_        = this->wcnt_;
+    duplicate->rcnt_        = this->rcnt_;
+    duplicate->bcnt_        = this->bcnt_;
+    duplicate->stride_      = this->stride_;
+    duplicate->pattern_     = this->pattern_;
+    duplicate->mem_speed_   = this->mem_speed_;
+    return duplicate;
   }
 
 };

--- a/samples/mem_tg/mem_tg.h
+++ b/samples/mem_tg/mem_tg.h
@@ -27,6 +27,7 @@
 #include <opae/cxx/core/token.h>
 #include <iostream>
 #include <vector>
+#include <string>
 
 #include "afu_test.h"
 
@@ -236,8 +237,9 @@ public:
     return handle_->get_token();
   }
 
+  // Duplicate contents of this mem_tg to duplicate_obj.
+  // commands_, current_command_, app_ are ommited since they are not relevant to closed instances of mem_tg that don't interact with commands.
   void duplicate(mem_tg *duplicate_obj) const {
-    
     duplicate_obj->count_       = this->count_;
     duplicate_obj->loop_        = this->loop_;
     duplicate_obj->wcnt_        = this->wcnt_;
@@ -248,16 +250,12 @@ public:
     duplicate_obj->mem_speed_   = this->mem_speed_;
     duplicate_obj->name_        = this->name_;
     duplicate_obj->afu_id_      = this->afu_id_;
-    //duplicate_obj->app_         = this->app_;
     duplicate_obj->pci_addr_    = this->pci_addr_;
     duplicate_obj->log_level_   = this->log_level_;
     duplicate_obj->shared_      = this->shared_;
     duplicate_obj->timeout_msec_ = this->timeout_msec_;
     duplicate_obj->handle_      = this->handle_;
-    //duplicate_obj->current_command_ = this->current_command_;
-    //duplicate_obj->commands_    = this->commands_;
     duplicate_obj->logger_      = this->logger_;
-    return;
   }
 
 };

--- a/samples/mem_tg/mem_tg.h
+++ b/samples/mem_tg/mem_tg.h
@@ -236,18 +236,28 @@ public:
     return handle_->get_token();
   }
 
-  mem_tg* duplicate() const {
-    mem_tg *duplicate = new mem_tg;
-
-    duplicate->count_       = this->count_;
-    duplicate->loop_        = this->loop_;
-    duplicate->wcnt_        = this->wcnt_;
-    duplicate->rcnt_        = this->rcnt_;
-    duplicate->bcnt_        = this->bcnt_;
-    duplicate->stride_      = this->stride_;
-    duplicate->pattern_     = this->pattern_;
-    duplicate->mem_speed_   = this->mem_speed_;
-    return duplicate;
+  void duplicate(mem_tg *duplicate_obj) const {
+    
+    duplicate_obj->count_       = this->count_;
+    duplicate_obj->loop_        = this->loop_;
+    duplicate_obj->wcnt_        = this->wcnt_;
+    duplicate_obj->rcnt_        = this->rcnt_;
+    duplicate_obj->bcnt_        = this->bcnt_;
+    duplicate_obj->stride_      = this->stride_;
+    duplicate_obj->pattern_     = this->pattern_;
+    duplicate_obj->mem_speed_   = this->mem_speed_;
+    duplicate_obj->name_        = this->name_;
+    duplicate_obj->afu_id_      = this->afu_id_;
+    //duplicate_obj->app_         = this->app_;
+    duplicate_obj->pci_addr_    = this->pci_addr_;
+    duplicate_obj->log_level_   = this->log_level_;
+    duplicate_obj->shared_      = this->shared_;
+    duplicate_obj->timeout_msec_ = this->timeout_msec_;
+    duplicate_obj->handle_      = this->handle_;
+    //duplicate_obj->current_command_ = this->current_command_;
+    //duplicate_obj->commands_    = this->commands_;
+    duplicate_obj->logger_      = this->logger_;
+    return;
   }
 
 };

--- a/samples/mem_tg/mem_tg.h
+++ b/samples/mem_tg/mem_tg.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2022, Intel Corporation
+// Copyright(c) 2022-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -67,7 +67,6 @@ const std::map<std::string, uint32_t> tg_pattern = {
   { "prbs31", TG_DATA_PRBS31},
   { "rot1",   TG_DATA_PRBS31},
 };
-
   
 enum {
   AFU_DFH         = 0x0000,
@@ -238,26 +237,26 @@ public:
   }
 
   // Duplicate contents of this mem_tg to duplicate_obj.
-  // commands_, current_command_, app_ are ommited since they are not relevant to closed instances of mem_tg that don't interact with commands.
+  // commands_, current_command_, app_ are ommited since they are not
+  // relevant to closed instances of mem_tg that don't interact with commands.
   void duplicate(mem_tg *duplicate_obj) const {
-    duplicate_obj->count_       = this->count_;
-    duplicate_obj->loop_        = this->loop_;
-    duplicate_obj->wcnt_        = this->wcnt_;
-    duplicate_obj->rcnt_        = this->rcnt_;
-    duplicate_obj->bcnt_        = this->bcnt_;
-    duplicate_obj->stride_      = this->stride_;
-    duplicate_obj->pattern_     = this->pattern_;
-    duplicate_obj->mem_speed_   = this->mem_speed_;
-    duplicate_obj->name_        = this->name_;
-    duplicate_obj->afu_id_      = this->afu_id_;
-    duplicate_obj->pci_addr_    = this->pci_addr_;
-    duplicate_obj->log_level_   = this->log_level_;
-    duplicate_obj->shared_      = this->shared_;
+    duplicate_obj->count_        = this->count_;
+    duplicate_obj->loop_         = this->loop_;
+    duplicate_obj->wcnt_         = this->wcnt_;
+    duplicate_obj->rcnt_         = this->rcnt_;
+    duplicate_obj->bcnt_         = this->bcnt_;
+    duplicate_obj->stride_       = this->stride_;
+    duplicate_obj->pattern_      = this->pattern_;
+    duplicate_obj->mem_speed_    = this->mem_speed_;
+    duplicate_obj->name_         = this->name_;
+    duplicate_obj->afu_id_       = this->afu_id_;
+    duplicate_obj->pci_addr_     = this->pci_addr_;
+    duplicate_obj->log_level_    = this->log_level_;
+    duplicate_obj->shared_       = this->shared_;
     duplicate_obj->timeout_msec_ = this->timeout_msec_;
-    duplicate_obj->handle_      = this->handle_;
-    duplicate_obj->logger_      = this->logger_;
+    duplicate_obj->handle_       = this->handle_;
+    duplicate_obj->logger_       = this->logger_;
   }
 
 };
 } // end of namespace mem_tg
-

--- a/samples/mem_tg/tg_test.h
+++ b/samples/mem_tg/tg_test.h
@@ -213,7 +213,7 @@ public:
           for (unsigned i = 0; i < tg_exe_->mem_ch_.size(); i++) {
             channels[i] = std::stoi(tg_exe_->mem_ch_[i]);
           }
-        } catch (std::invalid_argument& e) {
+        } catch (std::invalid_argument &e) {
           std::cerr << "Error: invalid argument to std::stoi";
           delete[] channels;
           return 1;

--- a/samples/mem_tg/tg_test.h
+++ b/samples/mem_tg/tg_test.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2022, Intel Corporation
+// Copyright(c) 2022-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -44,17 +44,18 @@ class tg_test : public test_command
 {
 public:
     tg_test()
-        :tg_exe_(NULL) {
-          tg_offset_ = 0x0;
-    }
-    virtual ~tg_test(){}
+        : tg_offset_(0x0)
+        , tg_exe_(NULL)
+    {}
 
-    virtual  const char *name() const override
+    virtual ~tg_test() {}
+
+    virtual const char *name() const override
     {
         return "tg_test";
     }
 
-    virtual  const char *description() const override
+    virtual const char *description() const override
     {
       return "configure & run mem traffic generator test";
     }
@@ -64,7 +65,6 @@ public:
       return AFU_ID;
     }
 
-
     // Convert number of transactions to bandwidth (GB/s)
     double bw_calc(uint64_t xfer_bytes, uint64_t num_ticks)
     {
@@ -72,32 +72,32 @@ public:
     }
 
     void tg_perf (mem_tg *tg_exe_) {
-      uint32_t mem_ch_offset = (std::stoi(tg_exe_->mem_ch_[0])) << 0x3;
-      uint64_t num_ticks = tg_exe_->read64(MEM_TG_CLOCKS + mem_ch_offset);
-      std::cout << "Mem Clock Cycles: " << std::dec << num_ticks << std::endl;
-      uint64_t write_bytes = 64 * (tg_exe_->loop_*tg_exe_->wcnt_*tg_exe_->bcnt_);
-      uint64_t read_bytes  = 64 * (tg_exe_->loop_*tg_exe_->rcnt_*tg_exe_->bcnt_);
+        uint32_t mem_ch_offset = (std::stoi(tg_exe_->mem_ch_[0])) << 0x3;
+        uint64_t num_ticks = tg_exe_->read64(MEM_TG_CLOCKS + mem_ch_offset);
+        std::cout << "Mem Clock Cycles: " << std::dec << num_ticks << std::endl;
 
-      std::cout << "Write BW: " << bw_calc(write_bytes,num_ticks) << " GB/s" << std::endl;
-      std::cout << "Read BW: "  << bw_calc(read_bytes,num_ticks)  << " GB/s\n" << std::endl;
+        uint64_t write_bytes = 64 * (tg_exe_->loop_*tg_exe_->wcnt_*tg_exe_->bcnt_);
+        uint64_t read_bytes  = 64 * (tg_exe_->loop_*tg_exe_->rcnt_*tg_exe_->bcnt_);
+        std::cout << "Write BW: " << bw_calc(write_bytes,num_ticks) << " GB/s" << std::endl;
+        std::cout << "Read BW: "  << bw_calc(read_bytes,num_ticks)  << " GB/s\n" << std::endl;
     }
   
     bool tg_wait_test_completion (mem_tg *tg_exe_)
     {
         /* Wait for test completion */
-        uint32_t           timeout = MEM_TG_TEST_TIMEOUT;
+        uint32_t timeout = MEM_TG_TEST_TIMEOUT;
         // poll while active bit is set (channel status = {pass,fail,timeout,active})
         uint32_t tg_status = 0x1;
-        tg_status = 0xF&(tg_exe_->read64(MEM_TG_STAT) >> (0x4*(std::stoi(tg_exe_->mem_ch_[0]))));
-        while ( tg_status == TG_STATUS_ACTIVE ) {
-          tg_status = 0xF&(tg_exe_->read64(MEM_TG_STAT) >> (0x4*(std::stoi(tg_exe_->mem_ch_[0]))));
-	        std::this_thread::yield();
+        tg_status = 0xF & (tg_exe_->read64(MEM_TG_STAT) >> (0x4*(std::stoi(tg_exe_->mem_ch_[0]))));
+        while (tg_status == TG_STATUS_ACTIVE) {
+          tg_status = 0xF & (tg_exe_->read64(MEM_TG_STAT) >> (0x4*(std::stoi(tg_exe_->mem_ch_[0]))));
+          std::this_thread::yield();
           if (--timeout == 0) {
             std::cout << "TG TEST TIME OUT" << std::endl;
             return false;
           }
         }
-	      std::cout << "Channel " << std::stoi(tg_exe_->mem_ch_[0]) << ":" << std::endl;
+        std::cout << "Channel " << std::stoi(tg_exe_->mem_ch_[0]) << ":" << std::endl;
       	if (tg_status == TG_STATUS_TIMEOUT) {
           std::cout << "TG TIMEOUT" << std::endl;
           return false;
@@ -120,15 +120,16 @@ public:
 
     int config_input_options(mem_tg *tg_exe_)
     {
-	    if (!tg_exe_)
-        return -1;
-	    uint64_t mem_capability = tg_exe_->read64(MEM_TG_CTRL);
+        if (!tg_exe_)
+          return -1;
+        uint64_t mem_capability = tg_exe_->read64(MEM_TG_CTRL);
     	if ((mem_capability & (0x1 << std::stoi(tg_exe_->mem_ch_[0]))) == 0) { 
-        std::cerr << "No traffic generator for mem[" << std::stoi(tg_exe_->mem_ch_[0]) << "]" << std::endl;
-        return -1;
-      } else {
+          std::cerr << "No traffic generator for mem[" << std::stoi(tg_exe_->mem_ch_[0]) << "]" << std::endl;
+          return -1;
+        }
+
         tg_offset_ = AFU_DFH + (MEM_TG_CFG_OFFSET * (1+std::stoi(tg_exe_->mem_ch_[0])));
-      }
+
         tg_exe_->write32(tg_offset_+TG_LOOP_COUNT,  tg_exe_->loop_);
         tg_exe_->write32(tg_offset_+TG_WRITE_COUNT, tg_exe_->wcnt_);
         tg_exe_->write32(tg_offset_+TG_READ_COUNT,  tg_exe_->rcnt_);
@@ -145,13 +146,13 @@ public:
     // The test state has been configured. Run one test instance.
     int run_mem_test(mem_tg *tg_exe_)
     {
-	    int status = 0;
+      int status = 0;
 	
       tg_exe_->logger_->debug("Start Test");
 
-      tg_exe_->write32(tg_offset_+TG_START,0x1);
+      tg_exe_->write32(tg_offset_ + TG_START, 0x1);
 
-      if(!tg_wait_test_completion(tg_exe_))
+      if (!tg_wait_test_completion(tg_exe_))
         status = -1;
 
       tg_perf(tg_exe_);
@@ -160,7 +161,7 @@ public:
     }
 
     int run_thread_single_channel(mem_tg *tg_exe_) {
-	    auto ret = config_input_options(tg_exe_);
+      auto ret = config_input_options(tg_exe_);
       if (ret != 0) {
         std::cerr << "Failed to configure TG input options" << std::endl;
         return ret;
@@ -171,8 +172,8 @@ public:
     virtual int run(test_afu *afu, CLI::App *app) override
     {
       (void)app;
-      auto d_afu = dynamic_cast<mem_tg*>(afu);
-      tg_exe_ = dynamic_cast<mem_tg*>(afu);
+      auto d_afu = dynamic_cast<mem_tg *>(afu);
+      tg_exe_ = dynamic_cast<mem_tg *>(afu);
 
       token_ = d_afu->get_token();
 
@@ -182,19 +183,18 @@ public:
         tg_exe_->mem_speed_ = 300;
         std::cout << "Memory channel clock frequency unknown. Assuming "
           << tg_exe_->mem_speed_ << " MHz." << std::endl;
-      }
-      else {
+      } else {
         std::cout << "Memory clock from command line: "
           << tg_exe_->mem_speed_ << " MHz" << std::endl;
       }
 
       if (0 >= (tg_exe_->mem_ch_).size()) {
         std::cout << "Insufficient arguments provided" << std::endl;
-	      exit(1);
+        exit(1);
       }
 
       // Parse mem_ch_ into array of selected channels and number of channels
-	    int *channels = NULL;
+      int *channels = NULL;
       int num_channels = 0;
       if ((tg_exe_->mem_ch_[0]).find("all") == 0) {	
         uint64_t mem_capability = tg_exe_->read64(MEM_TG_CTRL);
@@ -222,24 +222,24 @@ public:
       
       // Spawn threads for each channel:
       mem_tg *thread_tg_exe_objects[num_channels];
-	    std::vector<std::future<int>> futures;
+      std::vector<std::future<int>> futures;
       std::vector<std::promise<int>> promises(num_channels);
       std::vector<std::thread> threads;
       for (int i = 0; i < num_channels; i++) { 
         if (channels[i] == -1) break;
-	      thread_tg_exe_objects[i] = new mem_tg;
+        thread_tg_exe_objects[i] = new mem_tg;
         tg_exe_->duplicate(thread_tg_exe_objects[i]);
         thread_tg_exe_objects[i]->mem_ch_.clear();
         thread_tg_exe_objects[i]->mem_ch_.push_back(std::to_string(channels[i]));
         futures.push_back(promises[i].get_future());
         threads.emplace_back([&, i] { 
-			    promises[i].set_value(run_thread_single_channel(thread_tg_exe_objects[i])); 
-	      });
+          promises[i].set_value(run_thread_single_channel(thread_tg_exe_objects[i])); 
+	});
       }
 
       // Wait for all threads to exit then collect their exit statuses
       for (auto &thread : threads) {
-	      thread.join();
+        thread.join();
       }
       
       std::vector<int> exit_codes;
@@ -255,9 +255,9 @@ public:
       // Delete dynamic allocations 
       delete[] channels;
       for (int i = 0; i < num_channels; i++) {
-		    delete thread_tg_exe_objects[i];
-	    }
-	    return 0;
+        delete thread_tg_exe_objects[i];
+      }
+      return 0;
     }
 
 protected:

--- a/samples/mem_tg/tg_test.h
+++ b/samples/mem_tg/tg_test.h
@@ -37,9 +37,6 @@
 using test_afu = opae::afu_test::afu;
 using opae::fpga::types::token;
 
-#define NUM_AVAILABLE_CHANNELS 3
-const int AVAILABLE_CHANNELS[] = {0, 1, 2};
-
 namespace mem_tg {
 
 class tg_test : public test_command
@@ -73,7 +70,7 @@ public:
         return (double)(xfer_bytes) / ((1000.0 / (double)tg_exe_->mem_speed_ * (double)num_ticks));
     }
 
-    void tg_perf () {
+    void tg_perf (mem_tg *tg_exe_) {
       uint32_t mem_ch_offset = (std::stoi(tg_exe_->mem_ch_[0])) << 0x3;
       uint64_t num_ticks = tg_exe_->read64(MEM_TG_CLOCKS + mem_ch_offset);
       std::cout << "Mem Clock Cycles: " << std::dec << num_ticks << std::endl;
@@ -81,35 +78,28 @@ public:
       uint64_t read_bytes  = 64 * (tg_exe_->loop_*tg_exe_->rcnt_*tg_exe_->bcnt_);
 
       std::cout << "Write BW: " << bw_calc(write_bytes,num_ticks) << " GB/s" << std::endl;
-      std::cout << "Read BW: "  << bw_calc(read_bytes,num_ticks)  << " GB/s" << std::endl;
+      std::cout << "Read BW: "  << bw_calc(read_bytes,num_ticks)  << " GB/s\n" << std::endl;
     }
   
-    bool tg_wait_test_completion ()
+    bool tg_wait_test_completion (mem_tg *tg_exe_)
     {
         /* Wait for test completion */
         uint32_t           timeout = MEM_TG_TEST_TIMEOUT;
-        int max_itterations = 10000; // TODO: REMOVE AFTER TESTING
         // poll while active bit is set (channel status = {pass,fail,timeout,active})
         uint32_t tg_status = 0x1;
         tg_status = 0xF&(tg_exe_->read64(MEM_TG_STAT) >> (0x4*(std::stoi(tg_exe_->mem_ch_[0]))));
-        int i = 0; // TODO: REMOVE AFTER TESTING
         while ( tg_status == TG_STATUS_ACTIVE ) {
           tg_status = 0xF&(tg_exe_->read64(MEM_TG_STAT) >> (0x4*(std::stoi(tg_exe_->mem_ch_[0]))));
           // usleep(TEST_SLEEP_INVL);
-          std::this_thread::yield();
+	        std::this_thread::yield();
           if (--timeout == 0) {
             std::cout << "TG TEST TIME OUT" << std::endl;
             return false;
           }
 
-          // TODO: REMOVE AFTER TESTING
-          i++;
-          if (i >= max_itterations) {
-            std::cout << "EXCEEDED MAX ITTERATIONS ON CHANNEL "<< std::stoi(tg_exe_->mem_ch_[0]) << std::endl;
-            return false;
-          }
         }
-        if(tg_status == TG_STATUS_TIMEOUT) {
+	      std::cout << "Channel " << std::stoi(tg_exe_->mem_ch_[0]) << ":" << std::endl;
+      	if(tg_status == TG_STATUS_TIMEOUT) {
           std::cout << "TG TIMEOUT" << std::endl;
           return false;
         }
@@ -129,20 +119,17 @@ public:
         return true;
     }
 
-
     int config_input_options(mem_tg *tg_exe_)
     {
-        if (!tg_exe_)
-            return -1;
-
-        uint64_t mem_capability = tg_exe_->read64(MEM_TG_CTRL);
-        if((mem_capability & (0x1 << std::stoi(tg_exe_->mem_ch_[0]))) == 0) { 
+	    if (!tg_exe_)
+        return -1;
+	    uint64_t mem_capability = tg_exe_->read64(MEM_TG_CTRL);
+    	if((mem_capability & (0x1 << std::stoi(tg_exe_->mem_ch_[0]))) == 0) { 
           std::cerr << "No traffic generator for mem[" << std::stoi(tg_exe_->mem_ch_[0]) << "]" << std::endl;
           return -1;
         } else {
           tg_offset_ = AFU_DFH + (MEM_TG_CFG_OFFSET * (1+std::stoi(tg_exe_->mem_ch_[0])));
         }
-	
         tg_exe_->write32(tg_offset_+TG_LOOP_COUNT,  tg_exe_->loop_);
         tg_exe_->write32(tg_offset_+TG_WRITE_COUNT, tg_exe_->wcnt_);
         tg_exe_->write32(tg_offset_+TG_READ_COUNT,  tg_exe_->rcnt_);
@@ -153,34 +140,32 @@ public:
         // address increment mode
         tg_exe_->write32(tg_offset_+TG_ADDR_MODE_WR, TG_ADDR_SEQ);
         tg_exe_->write32(tg_offset_+TG_ADDR_MODE_RD, TG_ADDR_SEQ);
-
         return 0;
     }
 
     // The test state has been configured. Run one test instance.
     int run_mem_test(mem_tg *tg_exe_)
     {
-        int status = 0;
+	      int status = 0;
 	
         tg_exe_->logger_->debug("Start Test");
 
         tg_exe_->write32(tg_offset_+TG_START,0x1);
 
-        if(!tg_wait_test_completion())
+        if(!tg_wait_test_completion(tg_exe_))
           status = -1;
 
-        tg_perf();
+        tg_perf(tg_exe_);
 	
         return status;
     }
 
     int run_thread_single_channel(mem_tg *tg_exe_){
-      auto ret = config_input_options(tg_exe_);
+	      auto ret = config_input_options(tg_exe_);
         if (ret != 0) {
             std::cerr << "Failed to configure TG input options" << std::endl;
             return ret;
         }
-
         int status = run_mem_test(tg_exe_);
         return status;
     }
@@ -206,15 +191,21 @@ public:
         }
 
         // Parse mem_ch_ into array of selected channels and number of channels
-        int *channels = NULL;
+	int *channels = NULL;
         int num_channels = 0;
-        if (0 < tg_exe_->mem_ch_.size()) {
-          if (tg_exe_->mem_ch_[0] == "all"){
-            channels = new int[NUM_AVAILABLE_CHANNELS];
-            num_channels = NUM_AVAILABLE_CHANNELS;
-            for (int i = 0; i < NUM_AVAILABLE_CHANNELS; i++){
-              channels[i] = AVAILABLE_CHANNELS[i];
+        if (0 < (tg_exe_->mem_ch_).size()) {
+          if ((tg_exe_->mem_ch_[0]).find("all") == 0){	
+            uint64_t mem_capability = tg_exe_->read64(MEM_TG_CTRL);
+            channels = new int[sizeof(uint64_t)]; // size should be same as mem_capability 
+            int last = 0;
+            for (uint32_t i = 0; i < sizeof(uint64_t); i++){  // number of itterations should be same as mem_capability 
+              if ((mem_capability & (1ULL << i)) != 0){
+                channels[last] = i;
+                last += 1;
+              }
             }
+            channels[last] = -1; // EOL
+            num_channels = last;
           } else {
             channels = new int[tg_exe_->mem_ch_.size()];
             num_channels = tg_exe_->mem_ch_.size();
@@ -228,24 +219,30 @@ public:
               return 1;
             }
           }
-        }
+        } else {
+	        std::cout << "Insufficient arguments provided" << std::endl;
+	        exit(1);
+	      }
 
         // Spawn threads for each channel:
-        std::vector<mem_tg*> thread_tg_exe_objects;
-        std::vector<std::future<int>> futures;
+        mem_tg *thread_tg_exe_objects[num_channels];
+	      std::vector<std::future<int>> futures;
         std::vector<std::promise<int>> promises(num_channels);
         std::vector<std::thread> threads;
-        for (int i = 0; i < num_channels; i++){
-          thread_tg_exe_objects[i] = tg_exe_->duplicate();
+        for (int i = 0; i < num_channels; i++){ 
+          if (channels[i] == -1) break;
+	        thread_tg_exe_objects[i] = new mem_tg;
+          tg_exe_->duplicate(thread_tg_exe_objects[i]);
           thread_tg_exe_objects[i]->mem_ch_.clear();
           thread_tg_exe_objects[i]->mem_ch_.push_back(std::to_string(channels[i]));
           futures.push_back(promises[i].get_future());
-          threads.emplace_back([&] { promises[i].set_value(run_thread_single_channel(thread_tg_exe_objects[i])); });
+          threads.emplace_back([&, i] { 
+			      promises[i].set_value(run_thread_single_channel(thread_tg_exe_objects[i])); 
+	        });
         }
-
         // Wait for all threads to exit then collect their exit statuses
         for (auto &thread : threads){
-          thread.join();
+	        thread.join();
         }
         std::vector<int> exit_codes;
         for (auto& future : futures){
@@ -257,8 +254,12 @@ public:
           std::cout << "Thread on channel " << channels[i] << " exited with status " << (long)exit_codes[i] << std::endl;
         }
 
+        // Delete dynamic allocations 
         delete[] channels;
-        return 0;
+        for (int i = 0; i < num_channels; i++){
+		      delete thread_tg_exe_objects[i];
+	      }
+	      return 0;
     }
 
 protected:


### PR DESCRIPTION
- Added multi-channel capability to mem_tg test, specified in "-m, --mem-channel" argument, allowing bandwidth to be measured for several channels communicating in parallel.
    - User can specify a list of integers representing the 0 indexed channels to be run, or 'all' to run on all channels enumerated in MEM_TG_CTRL register.
    - Each channel gets a thread spawned for it that runs the preexistent configuration and run routines.
    - The results of each thread are logged in the same format as the previous version. 