### PR TITLE
fix fpga events PCIe Error status time

### DIFF
--- a/libraries/libboard/board_n6000/board_event_log.c
+++ b/libraries/libboard/board_n6000/board_event_log.c
@@ -783,13 +783,15 @@ void bel_print_pci_error_status(struct bel_pci_error_status *status, bool print_
 
 }
 
-void bel_print_pci_v1_error_status(struct bel_pcie_v1_error_status *status, bool print_bits)
+void bel_print_pci_v1_error_status(struct bel_pcie_v1_error_status *status, struct bel_timeof_day *timeof_day, bool print_bits)
 {
 
 	if (status->header.magic != BEL_PCI_V1_ERROR_STATUS)
 		return;
 
-	bel_print_header("PCI Error Status Time", &status->header);
+	/* PCIe errors are logged immediately after power on.
+	Time of the day information is written by SW into a BMC register.*/
+	bel_print_timeofday("PCI Error Status Time", timeof_day);
 
 	// PCIe Link Status
 	bel_print_value("PCIe Link Status", status->pcie_link_status);
@@ -967,7 +969,7 @@ void bel_print(struct bel_event *event, bool print_sensors, bool print_bits)
 		bel_print_sensors_state(&event->sensors_state);
 		bel_print_sensors_status(&event->sensors_status);
 	}
-	bel_print_pci_v1_error_status(&event->pcie_v1_error_status, print_bits);
+	bel_print_pci_v1_error_status(&event->pcie_v1_error_status, &event->timeof_day, print_bits);
 
 }
 

--- a/tests/board/test_board_n6000.cpp
+++ b/tests/board/test_board_n6000.cpp
@@ -88,7 +88,8 @@ extern "C" {
         struct bel_timeof_day* timeof_day,
         bool print_bits);
     void bel_print(struct bel_event* event, bool print_sensors, bool print_bits);
-    void bel_print_pci_v1_error_status(struct bel_pcie_v1_error_status* status, bool print_bits);
+    void bel_print_pci_v1_error_status(struct bel_pcie_v1_error_status *status,
+        struct bel_timeof_day *timeof_day, bool print_bits);
 }
 
 
@@ -512,7 +513,7 @@ TEST_P(board_dfl_n6000_c_p, board_n6000_13) {
     struct bel_pcie_v1_error_status pcie_v1_error_status;
     memset(&pcie_v1_error_status, 0x0, sizeof(pcie_v1_error_status));
     pcie_v1_error_status.header.magic = 0x53696D12;
-    EXPECT_NO_THROW(bel_print_pci_v1_error_status(&pcie_v1_error_status,true));
+    EXPECT_NO_THROW(bel_print_pci_v1_error_status(&pcie_v1_error_status, &timeof_day, true));
 
 }
 


### PR DESCRIPTION
The host writes the 'time of the day' to BMC registers (offset 0x178, 0x17C) periodically (every minute). BMC uses this value as the timestamp for error and event logging. In the scenario where 'PCI error status time' is incorrect, PCIe error is received before the host writes the 'time of the day' value to BMC registers. Therefore, BMC records the timestamp as approx epoch time (which is all 0's). 
power on event error displays the valid timestamp even though the timestamp in flash is recorded prior to the writing of 'time of day'