### PR TITLE
fuzz tests: add quiet option for report generation

### DIFF
--- a/tests/fuzzing/fuzz-bist_app.sh
+++ b/tests/fuzzing/fuzz-bist_app.sh
@@ -30,7 +30,7 @@
 # USAGE: bist_app [-s] [-v]
 fuzz_bist_app() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_bist_app <ITERS>\n"
+    printf "usage: fuzz_bist_app <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -38,6 +38,11 @@ fuzz_bist_app() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
   local -a short_parms=(\
 '-s' \
@@ -50,7 +55,7 @@ fuzz_bist_app() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "bist_app Fuzz Iteration: %d\n" $i
 
     cmd='bist_app '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -61,7 +66,7 @@ fuzz_bist_app() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/fuzz-dummy_afu.sh
+++ b/tests/fuzzing/fuzz-dummy_afu.sh
@@ -50,7 +50,7 @@
 
 fuzz_dummy_afu() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_dummy_afu <ITERS>\n"
+    printf "usage: fuzz_dummy_afu <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -58,6 +58,11 @@ fuzz_dummy_afu() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
 # dummy_afu short command line parameters
   local -a short_parms=(\
@@ -165,7 +170,7 @@ fuzz_dummy_afu() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "dummy_afu Fuzz Iteration: %d\n" $i
 
     cmd='dummy_afu '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -176,7 +181,7 @@ fuzz_dummy_afu() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
     cmd='dummy_afu '
@@ -188,7 +193,7 @@ fuzz_dummy_afu() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/fuzz-fpga_dma_N3000_test.sh
+++ b/tests/fuzzing/fuzz-fpga_dma_N3000_test.sh
@@ -44,7 +44,7 @@
 #	-G	Set AFU GUID
 fuzz_fpga_dma_N3000_test() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_fpga_dma_N3000_test <ITERS>\n"
+    printf "usage: fuzz_fpga_dma_N3000_test <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -52,6 +52,11 @@ fuzz_fpga_dma_N3000_test() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
   local -a short_parms=(\
 'use_ase=1' \
@@ -78,7 +83,7 @@ fuzz_fpga_dma_N3000_test() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "fpga_dma_N3000_test Fuzz Iteration: %d\n" $i
 
     cmd='fpga_dma_N3000_test '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -89,7 +94,7 @@ fuzz_fpga_dma_N3000_test() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/fuzz-fpga_dma_test.sh
+++ b/tests/fuzzing/fuzz-fpga_dma_test.sh
@@ -62,7 +62,7 @@
 
 fuzz_fpga_dma_test() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_fpga_dma_test <ITERS>\n"
+    printf "usage: fuzz_fpga_dma_test <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -70,6 +70,11 @@ fuzz_fpga_dma_test() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
 # fpga_dma_test short command line parameters
   local -a short_parms=(\
@@ -132,7 +137,7 @@ fuzz_fpga_dma_test() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "fpga_dma_test Fuzz Iteration: %d\n" $i
 
     cmd='fpga_dma_test '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -143,7 +148,7 @@ fuzz_fpga_dma_test() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
     cmd='fpga_dma_test '
@@ -155,7 +160,7 @@ fuzz_fpga_dma_test() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/fuzz-fpgabist.sh
+++ b/tests/fuzzing/fuzz-fpgabist.sh
@@ -44,7 +44,7 @@
 #                         Function number for specific FPGA
 fuzz_fpgabist() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_fpgabist <ITERS>\n"
+    printf "usage: fuzz_fpgabist <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -52,6 +52,11 @@ fuzz_fpgabist() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
   local -a short_parms=(\
 '-h' \
@@ -83,7 +88,7 @@ fuzz_fpgabist() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "fpgabist Fuzz Iteration: %d\n" $i
 
     cmd='fpgabist '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -94,7 +99,7 @@ fuzz_fpgabist() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
     cmd='fpgabist '
@@ -106,7 +111,7 @@ fuzz_fpgabist() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/fuzz-fpgaconf.sh
+++ b/tests/fuzzing/fuzz-fpgaconf.sh
@@ -45,7 +45,7 @@
 #                 -v,--version        Print version info and exit
 fuzz_fpgaconf() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_fpgaconf <ITERS>\n"
+    printf "usage: fuzz_fpgaconf <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -53,6 +53,11 @@ fuzz_fpgaconf() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
   local -a short_parms=(\
 '-h' \
@@ -96,7 +101,7 @@ fuzz_fpgaconf() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "fpgaconf Fuzz Iteration: %d\n" $i
 
     cmd='fpgaconf '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -107,7 +112,7 @@ fuzz_fpgaconf() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
     cmd='fpgaconf '
@@ -119,7 +124,7 @@ fuzz_fpgaconf() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/fuzz-fpgad.sh
+++ b/tests/fuzzing/fuzz-fpgad.sh
@@ -38,7 +38,7 @@
 #	-v,--version                display the version and exit.
 fuzz_fpgad() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_fpgad <ITERS>\n"
+    printf "usage: fuzz_fpgad <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -46,6 +46,11 @@ fuzz_fpgad() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
   local -a short_parms=(\
 '-d' \
@@ -84,7 +89,7 @@ fuzz_fpgad() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "fpgad Fuzz Iteration: %d\n" $i
 
     cmd='fpgad '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -95,7 +100,7 @@ fuzz_fpgad() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     coproc ${cmd} >"${fpgad_stdout_file}" 2>"${fpgad_stderr_file}"
     exec {fpgad_stderr_fd}<"${fpgad_stderr_file}"
     fpgad_stdin_fd=${COPROC[1]}
@@ -122,7 +127,7 @@ fuzz_fpgad() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     coproc ${cmd} >"${fpgad_stdout_file}" 2>"${fpgad_stderr_file}"
     exec {fpgad_stderr_fd}<"${fpgad_stderr_file}"
     fpgad_stdin_fd=${COPROC[1]}

--- a/tests/fuzzing/fuzz-fpgadiag.sh
+++ b/tests/fuzzing/fuzz-fpgadiag.sh
@@ -43,7 +43,7 @@
 
 fuzz_fpgadiag() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_fpgadiag <ITERS>\n"
+    printf "usage: fuzz_fpgadiag <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -51,6 +51,11 @@ fuzz_fpgadiag() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
 # fpgadiag short command line parameters
   local -a short_parms=(\
@@ -133,7 +138,7 @@ fuzz_fpgadiag() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "fpgadiag Fuzz Iteration: %d\n" $i
 
     cmd='fpgadiag '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -144,7 +149,7 @@ fuzz_fpgadiag() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
     cmd='fpgadiag '
@@ -156,7 +161,7 @@ fuzz_fpgadiag() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/fuzz-fpgainfo.sh
+++ b/tests/fuzzing/fuzz-fpgainfo.sh
@@ -101,7 +101,7 @@
 
 fuzz_fpgainfo() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_fpgainfo <ITERS>\n"
+    printf "usage: fuzz_fpgainfo <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -109,6 +109,11 @@ fuzz_fpgainfo() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
 # fpgainfo short command line parameters
   local -a short_parms=(\
@@ -227,7 +232,7 @@ fuzz_fpgainfo() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "fpgainfo Fuzz Iteration: %d\n" $i
 
     cmd='fpgainfo '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -238,7 +243,7 @@ fuzz_fpgainfo() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
     cmd='fpgainfo '
@@ -250,7 +255,7 @@ fuzz_fpgainfo() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/fuzz-fpgametrics.sh
+++ b/tests/fuzzing/fuzz-fpgametrics.sh
@@ -40,7 +40,7 @@
 #                -v,--version            Display version info and exit
 fuzz_fpgametrics() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_fpgametrics <ITERS>\n"
+    printf "usage: fuzz_fpgametrics <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -48,6 +48,11 @@ fuzz_fpgametrics() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
   local -a short_parms=(\
 '-h' \
@@ -89,7 +94,7 @@ fuzz_fpgametrics() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "fpgametrics Fuzz Iteration: %d\n" $i
 
     cmd='fpgametrics '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -100,7 +105,7 @@ fuzz_fpgametrics() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
     cmd='fpgametrics '
@@ -112,7 +117,7 @@ fuzz_fpgametrics() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/fuzz-hello_cxxcore.sh
+++ b/tests/fuzzing/fuzz-hello_cxxcore.sh
@@ -35,7 +35,7 @@
 
 fuzz_hello_cxxcore() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_hello_cxxcore <ITERS>\n"
+    printf "usage: fuzz_hello_cxxcore <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -43,6 +43,11 @@ fuzz_hello_cxxcore() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
   local -a short_parms=(\
 '-v' \
@@ -60,7 +65,7 @@ fuzz_hello_cxxcore() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "hello_cxxcore Fuzz Iteration: %d\n" $i
 
     cmd='hello_cxxcore '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -71,7 +76,7 @@ fuzz_hello_cxxcore() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
     cmd='hello_cxxcore '
@@ -83,7 +88,7 @@ fuzz_hello_cxxcore() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/fuzz-hello_events.sh
+++ b/tests/fuzzing/fuzz-hello_events.sh
@@ -37,7 +37,7 @@
 #                -v,--version        Print version info and exit
 fuzz_hello_events() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_hello_events <ITERS>\n"
+    printf "usage: fuzz_hello_events <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -45,6 +45,11 @@ fuzz_hello_events() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
   local -a short_parms=(\
 '-h' \
@@ -80,7 +85,7 @@ fuzz_hello_events() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "hello_events Fuzz Iteration: %d\n" $i
 
     cmd='hello_events '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -91,7 +96,7 @@ fuzz_hello_events() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
     cmd='hello_events '
@@ -103,7 +108,7 @@ fuzz_hello_events() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/fuzz-hello_fpga.sh
+++ b/tests/fuzzing/fuzz-hello_fpga.sh
@@ -39,7 +39,7 @@
 #                 -v,--version        Print version info and exit
 fuzz_hello_fpga() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_hello_fpga <ITERS>\n"
+    printf "usage: fuzz_hello_fpga <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -47,6 +47,11 @@ fuzz_hello_fpga() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
   local -a short_parms=(\
 '-h' \
@@ -86,7 +91,7 @@ fuzz_hello_fpga() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "hello_fpga Fuzz Iteration: %d\n" $i
 
     cmd='hello_fpga '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -97,7 +102,7 @@ fuzz_hello_fpga() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
     cmd='hello_fpga '
@@ -109,7 +114,7 @@ fuzz_hello_fpga() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/fuzz-host_exerciser.sh
+++ b/tests/fuzzing/fuzz-host_exerciser.sh
@@ -64,7 +64,7 @@
 
 fuzz_host_exerciser() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_host_exerciser <ITERS>\n"
+    printf "usage: fuzz_host_exerciser <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -72,6 +72,11 @@ fuzz_host_exerciser() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
   local -a short_parms=(\
 '-h' \
@@ -227,7 +232,7 @@ fuzz_host_exerciser() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "host_exerciser Fuzz Iteration: %d\n" $i
 
     cmd='host_exerciser '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -238,7 +243,7 @@ fuzz_host_exerciser() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
     cmd='host_exerciser '
@@ -250,7 +255,7 @@ fuzz_host_exerciser() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/fuzz-hps.sh
+++ b/tests/fuzzing/fuzz-hps.sh
@@ -63,7 +63,7 @@
 
 fuzz_hps() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_hps <ITERS>\n"
+    printf "usage: fuzz_hps <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -71,6 +71,11 @@ fuzz_hps() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
 # hps short command line parameters
   local -a short_parms=(\
@@ -168,7 +173,7 @@ fuzz_hps() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "hps Fuzz Iteration: %d\n" $i
 
     cmd='hps '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -179,7 +184,7 @@ fuzz_hps() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
     cmd='hps '
@@ -191,7 +196,7 @@ fuzz_hps() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/fuzz-hssi.sh
+++ b/tests/fuzzing/fuzz-hssi.sh
@@ -176,7 +176,7 @@
 #  --contmonitor UINT=0        time period(in seconds) for performance monitor
 fuzz_hssi() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_hssi <ITERS>\n"
+    printf "usage: fuzz_hssi <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -184,6 +184,11 @@ fuzz_hssi() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
   local -a short_parms=(\
 '-h' \
@@ -316,7 +321,7 @@ fuzz_hssi() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "hssi Fuzz Iteration: %d\n" $i
 
     cmd='hssi '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -371,7 +376,7 @@ fuzz_hssi() {
       ;;
     esac
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
     cmd='hssi '
@@ -427,7 +432,7 @@ fuzz_hssi() {
       ;;
     esac
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/fuzz-mem_tg.sh
+++ b/tests/fuzzing/fuzz-mem_tg.sh
@@ -57,7 +57,7 @@
 
 fuzz_mem_tg() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_mem_tg <ITERS>\n"
+    printf "usage: fuzz_mem_tg <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -65,6 +65,11 @@ fuzz_mem_tg() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
 # mem_tg short command line parameters
   local -a short_parms=(\
@@ -133,7 +138,7 @@ fuzz_mem_tg() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "mem_tg Fuzz Iteration: %d\n" $i
 
     cmd='mem_tg '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -144,7 +149,7 @@ fuzz_mem_tg() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
     cmd='mem_tg '
@@ -156,7 +161,7 @@ fuzz_mem_tg() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/fuzz-mmlink.sh
+++ b/tests/fuzzing/fuzz-mmlink.sh
@@ -38,7 +38,7 @@
 # <Version>             -v,--version Print version and exit
 fuzz_mmlink() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_mmlink <ITERS>\n"
+    printf "usage: fuzz_mmlink <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -46,6 +46,11 @@ fuzz_mmlink() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
   local -a short_parms=(\
 '-h' \
@@ -85,7 +90,7 @@ fuzz_mmlink() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "mmlink Fuzz Iteration: %d\n" $i
 
     cmd='mmlink '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -96,7 +101,7 @@ fuzz_mmlink() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
     cmd='mmlink '
@@ -108,7 +113,7 @@ fuzz_mmlink() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/fuzz-n5010-ctl.sh
+++ b/tests/fuzzing/fuzz-n5010-ctl.sh
@@ -38,7 +38,7 @@
 #  [-S <segment>] [-B <bus>] [-D <device>] [-F <function>] [PCI_ADDR]
 fuzz_n5010_ctl() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_n5010_ctl <ITERS>\n"
+    printf "usage: fuzz_n5010_ctl <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -46,6 +46,11 @@ fuzz_n5010_ctl() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
   local -a short_parms=(\
 '-h' \
@@ -89,7 +94,7 @@ fuzz_n5010_ctl() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "n5010-ctl Fuzz Iteration: %d\n" $i
 
     cmd='n5010-ctl '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -100,7 +105,7 @@ fuzz_n5010_ctl() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
     cmd='n5010-ctl '
@@ -112,7 +117,7 @@ fuzz_n5010_ctl() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/fuzz-n5010-test.sh
+++ b/tests/fuzzing/fuzz-n5010-test.sh
@@ -44,7 +44,7 @@
 
 fuzz_n5010_test() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_n5010_test <ITERS>\n"
+    printf "usage: fuzz_n5010_test <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -52,6 +52,11 @@ fuzz_n5010_test() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
   local -a short_parms=(\
 '-h' \
@@ -102,7 +107,7 @@ fuzz_n5010_test() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "n5010-test Fuzz Iteration: %d\n" $i
 
     cmd='n5010-test '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -113,7 +118,7 @@ fuzz_n5010_test() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
     cmd='n5010-test '
@@ -125,7 +130,7 @@ fuzz_n5010_test() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/fuzz-nlb0.sh
+++ b/tests/fuzzing/fuzz-nlb0.sh
@@ -62,7 +62,7 @@
 
 fuzz_nlb0() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_nlb0 <ITERS>\n"
+    printf "usage: fuzz_nlb0 <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -70,6 +70,11 @@ fuzz_nlb0() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
   local -a short_parms=(\
 '-h' \
@@ -178,7 +183,7 @@ fuzz_nlb0() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "nlb0 Fuzz Iteration: %d\n" $i
 
     cmd='nlb0 '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -189,7 +194,7 @@ fuzz_nlb0() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
     cmd='nlb0 '
@@ -201,7 +206,7 @@ fuzz_nlb0() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/fuzz-nlb3.sh
+++ b/tests/fuzzing/fuzz-nlb3.sh
@@ -65,7 +65,7 @@
 #    --suppress-stats Show stas at end
 fuzz_nlb3() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_nlb3 <ITERS>\n"
+    printf "usage: fuzz_nlb3 <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -73,6 +73,11 @@ fuzz_nlb3() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
   local -a short_parms=(\
 '-h' \
@@ -188,7 +193,7 @@ fuzz_nlb3() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "nlb3 Fuzz Iteration: %d\n" $i
 
     cmd='nlb3 '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -199,7 +204,7 @@ fuzz_nlb3() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
     cmd='nlb3 '
@@ -211,7 +216,7 @@ fuzz_nlb3() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/fuzz-nlb7.sh
+++ b/tests/fuzzing/fuzz-nlb7.sh
@@ -54,7 +54,7 @@
 
 fuzz_nlb7() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_nlb7 <ITERS>\n"
+    printf "usage: fuzz_nlb7 <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -62,6 +62,11 @@ fuzz_nlb7() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
   local -a short_parms=(\
 '-h' \
@@ -161,7 +166,7 @@ fuzz_nlb7() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "nlb7 Fuzz Iteration: %d\n" $i
 
     cmd='nlb7 '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -172,7 +177,7 @@ fuzz_nlb7() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
     cmd='nlb7 '
@@ -184,7 +189,7 @@ fuzz_nlb7() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/fuzz-object_api.sh
+++ b/tests/fuzzing/fuzz-object_api.sh
@@ -39,7 +39,7 @@
 
 fuzz_object_api() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_object_api <ITERS>\n"
+    printf "usage: fuzz_object_api <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -47,6 +47,11 @@ fuzz_object_api() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
   local -a short_parms=(\
 '-h' \
@@ -86,7 +91,7 @@ fuzz_object_api() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "object_api Fuzz Iteration: %d\n" $i
 
     cmd='object_api '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -97,7 +102,7 @@ fuzz_object_api() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
     cmd='object_api '
@@ -109,24 +114,14 @@ fuzz_object_api() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done
 }
 
-
-
-declare -i iters=1
-if [ $# -gt 0 ]; then
-  iters=$1
-fi
-fuzz_object_api ${iters}
-
-
-
 #declare -i iters=1
 #if [ $# -gt 0 ]; then
 #  iters=$1
 #fi
-#fuzz_object_api ${iter}
+#fuzz_object_api ${iters}

--- a/tests/fuzzing/fuzz-opae.io.sh
+++ b/tests/fuzzing/fuzz-opae.io.sh
@@ -74,7 +74,7 @@
 #             "$ opae.io -d 0000:00:00.0 -r 0 script.py a b c"
 fuzz_opae_io() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_opae_io <ITERS>\n"
+    printf "usage: fuzz_opae_io <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -82,6 +82,11 @@ fuzz_opae_io() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
   local -a short_parms=(\
 '-h' \
@@ -175,7 +180,7 @@ fuzz_opae_io() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "opae.io Fuzz Iteration: %d\n" $i
 
     cmd='opae.io '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -250,7 +255,7 @@ fuzz_opae_io() {
       ;;
     esac
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     coproc ${cmd} >"${stdout_file}" 2>"${stderr_file}"
     exec {stderr_fd}<"${stderr_file}"
     stdin_fd=${COPROC[1]}
@@ -341,7 +346,7 @@ fuzz_opae_io() {
       ;;
     esac
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     coproc ${cmd} >"${stdout_file}" 2>"${stderr_file}"
     exec {stderr_fd}<"${stderr_file}"
     stdin_fd=${COPROC[1]}

--- a/tests/fuzzing/fuzz-opaeuiotest.sh
+++ b/tests/fuzzing/fuzz-opaeuiotest.sh
@@ -32,7 +32,7 @@
 #        where <dfl device> is of the form dfl_dev.X
 fuzz_opaeuiotest() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_opaeuiotest <ITERS>\n"
+    printf "usage: fuzz_opaeuiotest <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -40,6 +40,11 @@ fuzz_opaeuiotest() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
   local -a short_parms=( 'dfl_dev.0' )
   local -a long_parms=( '0000:00:00.0' )
@@ -50,7 +55,7 @@ fuzz_opaeuiotest() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "opaeuiotest Fuzz Iteration: %d\n" $i
 
     cmd='opaeuiotest '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -61,7 +66,7 @@ fuzz_opaeuiotest() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
     cmd='opaeuiotest '
@@ -73,7 +78,7 @@ fuzz_opaeuiotest() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/fuzz-opaevfiotest.sh
+++ b/tests/fuzzing/fuzz-opaevfiotest.sh
@@ -34,7 +34,7 @@
 
 fuzz_opaevfiotest() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_opaevfiotest <ITERS>\n"
+    printf "usage: fuzz_opaevfiotest <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -43,6 +43,10 @@ fuzz_opaevfiotest() {
   local -i p
   local -i n
 
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
   local -a long_parms=(\
 '--help' \
@@ -65,7 +69,7 @@ fuzz_opaevfiotest() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "opaevfiotest Fuzz Iteration: %d\n" $i
 
     cmd='opaevfiotest '
     let "num_parms = 1 + ${RANDOM} % ${#long_parms[@]}"
@@ -76,7 +80,7 @@ fuzz_opaevfiotest() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/fuzz-userclk.sh
+++ b/tests/fuzzing/fuzz-userclk.sh
@@ -43,7 +43,7 @@
 
 fuzz_userclk() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_userclk <ITERS>\n"
+    printf "usage: fuzz_userclk <ITERS> [QUIET]\n"
     exit 1
   fi
 
@@ -51,6 +51,11 @@ fuzz_userclk() {
   local -i i
   local -i p
   local -i n
+
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
 
 # userclk short command line parameters
   local -a short_parms=(\
@@ -101,7 +106,7 @@ fuzz_userclk() {
 
   for (( i = 0 ; i < ${iters} ; ++i )); do
 
-    printf "Fuzz Iteration: %d\n" $i
+    printf "userclk Fuzz Iteration: %d\n" $i
 
     cmd='userclk '
     let "num_parms = 1 + ${RANDOM} % ${#short_parms[@]}"
@@ -112,7 +117,7 @@ fuzz_userclk() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
     cmd='userclk '
@@ -124,7 +129,7 @@ fuzz_userclk() {
       cmd="${cmd} ${parm}"
     done
 
-    printf "%s\n" "${cmd}"
+    [ ${quiet} -eq 0 ] && printf "%s\n" "${cmd}"
     ${cmd}
 
   done

--- a/tests/fuzzing/main.sh
+++ b/tests/fuzzing/main.sh
@@ -60,40 +60,45 @@ source fuzz-opaevfiotest.sh
 
 fuzz_all() {
   if [ $# -lt 1 ]; then
-    printf "usage: fuzz_all <ITERS>\n"
+    printf "usage: fuzz_all <ITERS> [QUIET]\n"
     exit 1
   fi
   local -i iters=$1
 
-  fuzz_fpgaconf ${iters}
-  fuzz_fpgainfo ${iters}
-  fuzz_fpgad ${iters}
-  fuzz_mmlink ${iters}
-  fuzz_hello_fpga ${iters}
-  fuzz_hello_events ${iters}
-  fuzz_userclk ${iters}
-  fuzz_fpgametrics ${iters}
-  fuzz_hello_cxxcore ${iters}
-  fuzz_n5010_ctl ${iters}
-  fuzz_n5010_test ${iters}
-  fuzz_host_exerciser ${iters}
-  fuzz_opaeuiotest ${iters}
-  fuzz_bist_app ${iters}
-  fuzz_dummy_afu ${iters}
-  fuzz_fpgabist ${iters}
-  fuzz_nlb3 ${iters}
-  fuzz_fpgadiag ${iters}
-  fuzz_fpga_dma_N3000_test ${iters}
-  fuzz_fpga_dma_test ${iters}
-  fuzz_mem_tg ${iters}
-  fuzz_opae_io ${iters}
-  fuzz_hps ${iters}  
-  fuzz_hssi ${iters}
-  fuzz_hps ${iters}
-  fuzz_nlb0 ${iters}
-  fuzz_nlb7 ${iters}
-  fuzz_object_api ${iters}
-  fuzz_opaevfiotest ${iters}
+  local -i quiet=0
+  if [ $# -gt 1 ]; then
+    quiet=$2
+  fi
+
+  fuzz_fpgaconf ${iters} ${quiet}
+  fuzz_fpgainfo ${iters} ${quiet}
+  fuzz_fpgad ${iters} ${quiet}
+  fuzz_mmlink ${iters} ${quiet}
+  fuzz_hello_fpga ${iters} ${quiet}
+  fuzz_hello_events ${iters} ${quiet}
+  fuzz_userclk ${iters} ${quiet}
+  fuzz_fpgametrics ${iters} ${quiet}
+  fuzz_hello_cxxcore ${iters} ${quiet}
+  fuzz_n5010_ctl ${iters} ${quiet}
+  fuzz_n5010_test ${iters} ${quiet}
+  fuzz_host_exerciser ${iters} ${quiet}
+  fuzz_opaeuiotest ${iters} ${quiet}
+  fuzz_bist_app ${iters} ${quiet}
+  fuzz_dummy_afu ${iters} ${quiet}
+  fuzz_fpgabist ${iters} ${quiet}
+  fuzz_nlb3 ${iters} ${quiet}
+  fuzz_fpgadiag ${iters} ${quiet}
+  fuzz_fpga_dma_N3000_test ${iters} ${quiet}
+  fuzz_fpga_dma_test ${iters} ${quiet}
+  fuzz_mem_tg ${iters} ${quiet}
+  fuzz_opae_io ${iters} ${quiet}
+  fuzz_hps ${iters} ${quiet}
+  fuzz_hssi ${iters} ${quiet}
+  fuzz_hps ${iters} ${quiet}
+  fuzz_nlb0 ${iters} ${quiet}
+  fuzz_nlb7 ${iters} ${quiet}
+  fuzz_object_api ${iters} ${quiet}
+  fuzz_opaevfiotest ${iters} ${quiet}
 
 }
 
@@ -101,4 +106,11 @@ declare -i iters=1
 if [ $# -gt 0 ]; then
   iters=$1
 fi
-fuzz_all ${iters}
+
+declare -i quiet=0
+if [ $# -gt 1 ] && [ $2 = '-q' ]; then
+  quiet=1
+fi
+
+fuzz_all ${iters} ${quiet}
+printf "\nAll fuzz tests PASSED\n"


### PR DESCRIPTION
Adds a -q option to filter out the radamsa output. This is desirable when creating verification reports. To use this, run the tests like:

$ ./main.sh 3 -q 2>/dev/null