### PR TITLE
fix: address cmake policy 148

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,8 +76,7 @@ mark_as_advanced(OPAE_BUILD_TESTS)
 ############################################################################
 set(OPAE_PYTHON_VERSION 3 CACHE STRING "Python version to use for building/distributing pyopae")
 set_property(CACHE OPAE_PYTHON_VERSION PROPERTY STRINGS 3 3.6 3.7 3.8 3.9 3.10 3.11)
-find_package(PythonInterp ${OPAE_PYTHON_VERSION})
-find_package(PythonLibs ${OPAE_PYTHON_VERSION})
+find_package(Python3 COMPONENTS Interpreter Development)
 
 ################################################################################
 # util-linux/libuuid
@@ -416,7 +415,7 @@ set(PYBIND11_URL
         https://github.com/pybind/pybind11.git
         CACHE STRING "URL for pybind11")
 
-if(${CMAKE_VERSION} VERSION_LESS "3.4.0" AND ${PYTHONLIBS_VERSION_STRING} VERSION_LESS "3.9.0")
+if(${CMAKE_VERSION} VERSION_LESS "3.4.0" AND ${Python3_VERSION} VERSION_LESS "3.9.0")
     set(PYBIND11_VERSION
         2.4.3
         CACHE STRING "Version for pybind11")

--- a/binaries/fpgadiag/CMakeLists.txt
+++ b/binaries/fpgadiag/CMakeLists.txt
@@ -112,7 +112,7 @@ if (OPAE_WITH_PYBIND11)
 
     add_custom_command(
         OUTPUT ${OUTPUT}
-        COMMAND ${PYTHON_EXECUTABLE} -m pip install --root=${PYDIST_STAGE_DIR}/build --no-warn-script-location .
+        COMMAND ${Python3_EXECUTABLE} -m pip install --root=${PYDIST_STAGE_DIR}/build --no-warn-script-location .
         COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
         WORKING_DIRECTORY ${PYDIST_STAGE_DIR}
         DEPENDS pyproject.toml setup.py ${PKG_FILES}

--- a/binaries/hssi/CMakeLists.txt
+++ b/binaries/hssi/CMakeLists.txt
@@ -29,7 +29,7 @@ file(GLOB_RECURSE PKG_FILES ${CMAKE_CURRENT_SOURCE_DIR}/ethernet/*.py)
 
 add_custom_command(
     OUTPUT ${OUTPUT}
-    COMMAND ${PYTHON_EXECUTABLE} -m pip install --root=${CMAKE_CURRENT_SOURCE_DIR}/build --no-warn-script-location .
+    COMMAND ${Python3_EXECUTABLE} -m pip install --root=${CMAKE_CURRENT_SOURCE_DIR}/build --no-warn-script-location .
     COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS pyproject.toml ${PKG_FILES}

--- a/binaries/ofs.uio/CMakeLists.txt
+++ b/binaries/ofs.uio/CMakeLists.txt
@@ -28,7 +28,7 @@ set(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/timestamp)
 
 add_custom_command(
     OUTPUT ${OUTPUT}
-    COMMAND ${PYTHON_EXECUTABLE} -m pip install --root=${CMAKE_CURRENT_SOURCE_DIR}/build --no-warn-script-location .
+    COMMAND ${Python3_EXECUTABLE} -m pip install --root=${CMAKE_CURRENT_SOURCE_DIR}/build --no-warn-script-location .
     COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS pyproject.toml ${PKG_FILES}

--- a/binaries/opae.io/CMakeLists.txt
+++ b/binaries/opae.io/CMakeLists.txt
@@ -34,7 +34,7 @@ if (PLATFORM_SUPPORTS_VFIO AND OPAE_WITH_PYBIND11 AND OPAE_WITH_LIBEDIT)
     if (NOT (CMAKE_VERSION VERSION_LESS 3.0))
         target_link_libraries(opae.io PRIVATE pybind11::embed dl util ${libedit_LIBRARIES} opaevfio)
     else()
-        target_link_libraries(opae.io PRIVATE ${PYTHON_LIBRARIES} dl util ${libedit_LIBRARIES} opaevfio)
+        target_link_libraries(opae.io PRIVATE ${Python3_LIBRARIES} dl util ${libedit_LIBRARIES} opaevfio)
     endif()
 
     if (libedit_IMPORTED)
@@ -43,7 +43,7 @@ if (PLATFORM_SUPPORTS_VFIO AND OPAE_WITH_PYBIND11 AND OPAE_WITH_LIBEDIT)
 
     target_include_directories(opae.io
         PUBLIC ${OPAE_INCLUDE_DIR}
-        PRIVATE ${PYTHON_INCLUDE_DIRS}
+        PRIVATE ${Python3_INCLUDE_DIRS}
         PRIVATE ${pybind11_ROOT}/include
         PRIVATE ${libedit_INCLUDE_DIRS}
     )
@@ -80,7 +80,7 @@ if (PLATFORM_SUPPORTS_VFIO AND OPAE_WITH_PYBIND11 AND OPAE_WITH_LIBEDIT)
 
     add_custom_command(
         OUTPUT ${OUTPUT}
-        COMMAND ${PYTHON_EXECUTABLE} -m pip install --root=${PYDIST_STAGE_DIR}/build .
+        COMMAND ${Python3_EXECUTABLE} -m pip install --root=${PYDIST_STAGE_DIR}/build .
         COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
         WORKING_DIRECTORY ${PYDIST_STAGE_DIR}
         DEPENDS ${PYFILES} ${PKG_FILES}

--- a/cmake/modules/OFS.cmake
+++ b/cmake/modules/OFS.cmake
@@ -28,7 +28,7 @@
 macro(ofs_add_driver yml_file driver)
     add_custom_command(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${driver}.h
-	COMMAND ${PYTHON_EXECUTABLE} ${OPAE_LIB_SOURCE}/scripts/ofs/ofs_parse.py
+	COMMAND ${Python3_EXECUTABLE} ${OPAE_LIB_SOURCE}/scripts/ofs/ofs_parse.py
         ${CMAKE_CURRENT_LIST_DIR}/${yml_file} --use-local-refs headers c ${CMAKE_CURRENT_BINARY_DIR} --driver ${driver}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         DEPENDS

--- a/cmake/modules/OPAEPackaging.cmake
+++ b/cmake/modules/OPAEPackaging.cmake
@@ -151,7 +151,7 @@ function(opae_python_install)
     #            set(ENV{DESTDIR} /)
     #        endif()
     #        execute_process(
-    #            COMMAND ${PYTHON_EXECUTABLE} setup.py install -O1 \
+    #            COMMAND ${Python3_EXECUTABLE} setup.py install -O1 \
     #                --single-version-externally-managed \
     #                --root=\$ENV{DESTDIR} \
     #                --prefix=${CMAKE_INSTALL_PREFIX} \
@@ -169,7 +169,7 @@ function(opae_python_install)
                 set(ENV{DESTDIR} /)
             endif()
             execute_process(
-                COMMAND ${PYTHON_EXECUTABLE} -m pip install \
+                COMMAND ${Python3_EXECUTABLE} -m pip install \
                     --root=\$ENV{DESTDIR} \
                     --prefix=${CMAKE_INSTALL_PREFIX} \
 		    --no-warn-script-location .

--- a/libraries/pyopae/CMakeLists.txt
+++ b/libraries/pyopae/CMakeLists.txt
@@ -55,7 +55,7 @@ opae_add_module_library(TARGET _opae
 
 target_include_directories(_opae
     PRIVATE ${pybind11_INCLUDE_DIRS}
-    PRIVATE ${PYTHON_INCLUDE_DIRS})
+    PRIVATE ${Python3_INCLUDE_DIRS})
 
 set_target_properties(_opae
     PROPERTIES PREFIX ""
@@ -100,7 +100,7 @@ if (OPAE_BUILD_PYTHON_DIST)
     endforeach(cppfile ${PYOPAE_SRC})
 
     add_custom_target(pyopae-dist
-        COMMAND ${PYTHON_EXECUTABLE} -m pip install --root=${PYDIST_STAGE_DIR}/build .
+        COMMAND ${Python3_EXECUTABLE} -m pip install --root=${PYDIST_STAGE_DIR}/build .
         DEPENDS ${PYFILES} ${PYOPAE_SRC}
         WORKING_DIRECTORY ${PYDIST_STAGE_DIR}
         COMMENT "Building Python distrubutions")

--- a/libraries/pyopaeuio/CMakeLists.txt
+++ b/libraries/pyopaeuio/CMakeLists.txt
@@ -42,7 +42,7 @@ if (OPAE_WITH_PYBIND11)
 
     add_custom_command(
         OUTPUT ${OUTPUT}
-	COMMAND ${PYTHON_EXECUTABLE} -m pip install --root=${PYDIST_STAGE_DIR}/build .
+	COMMAND ${Python3_EXECUTABLE} -m pip install --root=${PYDIST_STAGE_DIR}/build .
         COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
         WORKING_DIRECTORY ${PYDIST_STAGE_DIR}
 	DEPENDS ${PYFILES} pyopaeuio.cpp pyopaeuio.h

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -31,11 +31,6 @@ project(python)
 ############################################################################
 ## Find Python by version     ##############################################
 ############################################################################
-set(OPAE_PYTHON_VERSION 3.6 CACHE STRING "Python version to use for building/distributing pyopae")
-set_property(CACHE OPAE_PYTHON_VERSION PROPERTY STRINGS 2.7 3.6 3.5 3.4 3.3)
-
-find_package(PythonInterp ${OPAE_PYTHON_VERSION})
-find_package(PythonLibs ${OPAE_PYTHON_VERSION})
 
 add_subdirectory(opae.admin)
 add_subdirectory(pacsign)

--- a/python/opae.admin/CMakeLists.txt
+++ b/python/opae.admin/CMakeLists.txt
@@ -47,17 +47,17 @@ add_custom_command(TARGET opae.admin PRE_BUILD
 
 
 add_custom_target(opae.admin.src
-    COMMAND ${PYTHON_EXECUTABLE} setup.py sdist
+    COMMAND ${Python3_EXECUTABLE} setup.py sdist
     WORKING_DIRECTORY ${ADMIN_STAGE_DIR}
     COMMENT "Building opae.admin Python source distribution"
     )
 add_custom_target(opae.admin.wheel
-    COMMAND ${PYTHON_EXECUTABLE} setup.py bdist_wheel --universal
+    COMMAND ${Python3_EXECUTABLE} setup.py bdist_wheel --universal
     WORKING_DIRECTORY ${ADMIN_STAGE_DIR}
     COMMENT "Building opae.admin Python wheel distribution"
     )
 add_custom_target(opae.admin.tox
-    COMMAND ${PYTHON_EXECUTABLE} -m tox opae
+    COMMAND ${Python3_EXECUTABLE} -m tox opae
     DEPENDS opae.admin
     WORKING_DIRECTORY ${ADMIN_STAGE_DIR}
     COMMENT "Running tox on opae.admin"

--- a/tests/pyopae/CMakeLists.txt
+++ b/tests/pyopae/CMakeLists.txt
@@ -27,8 +27,8 @@
 try_compile(SUPPORTS_EMBEDDED_PYTHON
     ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/test_embed.cpp
     CMAKE_FLAGS
-    "-DINCLUDE_DIRECTORIES=${PYTHON_INCLUDE_DIRS};${pybind11_INCLUDE_DIRS}"
-    LINK_LIBRARIES ${PYTHON_LIBRARIES}
+    "-DINCLUDE_DIRECTORIES=${Python3_INCLUDE_DIRS};${pybind11_INCLUDE_DIRS}"
+    LINK_LIBRARIES ${Python3_LIBRARIES}
     OUTPUT_VARIABLE TRY_COMPILE_OUTPUT
 )
 
@@ -64,7 +64,7 @@ if (SUPPORTS_EMBEDDED_PYTHON)
         OPAE_EMBEDDED)
     target_include_directories(test_pyopae
         PRIVATE ${pybind11_INCLUDE_DIRS}
-        PRIVATE ${PYTHON_INCLUDE_DIRS}
+        PRIVATE ${Python3_INCLUDE_DIRS}
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
         PRIVATE ${opae-test_ROOT}/framework)
 
@@ -74,7 +74,7 @@ if (SUPPORTS_EMBEDDED_PYTHON)
             opae-cxx-core
             ${OPAE_TEST_LIBRARIES}
             ${json-c_LIBRARIES}
-            ${PYTHON_LIBRARIES})
+            ${Python3_LIBRARIES})
 
     macro(add_pyopae_test pytest)
         add_custom_command(TARGET test_pyopae


### PR DESCRIPTION
### Description
https://cmake.org/cmake/help/latest/policy/CMP0148.html

FindPythonInterp and FindPythonLibs are deprecated as of cmake 3.12. Recent cmake versions remove these altogether. The fix involves using

find_package(Python3 COMPONENTS Interpreter Development)

instead of find_package(PythonInterp and find_package(PythonLibs.

The following variable names are also updated, reflecting our dependency on Python 3:

PYTHON_EXECUTABLE   -> Python3_EXECUTABLE
PYTHON_INCLUDE_DIRS -> Python3_INCLUDE_DIRS
PYTHON_LIBRARIES    -> Python3_LIBRARIES

### Collateral (docs, reports, design examples, case IDs):
N/A

- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:

### Tests run:
Build with OPAE_BUILD_TESTS=ON, Ubuntu 22.04.
Build with OPAE_BUILD_TESTS=ON, Fedora 36.
Build with OPAE_BUILD_TESTS=ON, Rocky Linux 9.
Build with OPAE_BUILD_TESTS=ON, OpenSUSE Tumbleweed.