### PR TITLE
Feature: add a method for binding shared virtual addressing

### DIFF
--- a/binaries/opae.io/opae/io/utils.py
+++ b/binaries/opae.io/opae/io/utils.py
@@ -63,8 +63,12 @@ def hex_int(inp):
     return int(inp, 0)
 
 
-def load_driver(driver):
-    return subprocess.call(['modprobe', driver])
+def load_driver(driver, quiet=0):
+    cmd = ['modprobe']
+    if quiet:
+        cmd += ['-q']
+    cmd += [driver]
+    return subprocess.call(cmd)
 
 
 def get_bound_driver(pci_addr):
@@ -140,6 +144,7 @@ def vfio_init(pci_addr, new_owner='', force=False):
         LOG.info('Unbinding {} from {}'.format(msg, driver))
         unbind_driver(driver, pci_addr)
 
+    load_driver('dfl-pci-sva', quiet=1)
     load_driver('vfio-pci')
 
     print('Binding {} to vfio-pci'.format(msg))

--- a/binaries/opae.io/opae/io/utils.py
+++ b/binaries/opae.io/opae/io/utils.py
@@ -112,6 +112,13 @@ def put_dev_dict(file_name, dev_dict):
         pickle.dump(dev_dict, outf)
 
 
+def chown_pci_sva(pci_addr, uid, gid):
+    sva_bind_dev = os.path.join('/dev/dfl-pci-sva', pci_addr)
+    if os.path.exists(sva_bind_dev):
+        LOG.info('Setting owner of {}'.format(sva_bind_dev))
+        os.chown(sva_bind_dev, uid, gid)
+
+
 def vfio_init(pci_addr, new_owner='', force=False):
     vid_did = pci.vid_did_for_address(pci_addr)
     driver = get_bound_driver(pci_addr)
@@ -202,6 +209,7 @@ def vfio_init(pci_addr, new_owner='', force=False):
         os.chown(device, user, group)
         LOG.info('Changing permissions for {} to rw-rw----'.format(device))
         os.chmod(device, 0o660)
+        chown_pci_sva(pci_addr, user, group)
 
 
 def vfio_release(pci_addr):
@@ -244,6 +252,8 @@ def vfio_release(pci_addr):
             put_dev_dict(PICKLE_FILE, dev_dict)
         else:
             os.remove(PICKLE_FILE)
+
+    chown_pci_sva(pci_addr, 0, 0)
 
 
 class opae_register(Union):

--- a/include/opae/buffer.h
+++ b/include/opae/buffer.h
@@ -135,6 +135,18 @@ fpga_result fpgaReleaseBuffer(fpga_handle handle, uint64_t wsid);
 fpga_result fpgaGetIOAddress(fpga_handle handle, uint64_t wsid,
 			     uint64_t *ioaddr);
 
+/**
+ * Bind IOMMU shared virtual addressing
+ *
+ * When PCIe PASID, ATS and PRS capabilities are enabled, some platforms
+ * supporting binding the IOMMU to user space virtual addresses.
+ *
+ * @param[in]  handle   Handle to previously opened accelerator resource
+ * @param[out] pasid    Process address space ID, set if not NULL.
+ * @returns FPGA_OK on success and FPGA_NOT_SUPPORTED otherwise.
+ */
+fpga_result fpgaBindSVA(fpga_handle handle, uint32_t *pasid);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/libraries/libopae-c/adapter.h
+++ b/libraries/libopae-c/adapter.h
@@ -102,6 +102,8 @@ typedef struct _opae_api_adapter_table {
 
 	fpga_result (*fpgaGetIOAddress)(fpga_handle handle, uint64_t wsid,
 					uint64_t *ioaddr);
+	fpga_result (*fpgaBindSVA)(fpga_handle handle, uint32_t *pasid);
+
 	/*
 	**	fpga_result (*fpgaGetOPAECVersion)(fpga_version *version);
 	**

--- a/libraries/libopae-c/api-shell.c
+++ b/libraries/libopae-c/api-shell.c
@@ -953,6 +953,20 @@ fpga_result __OPAE_API__ fpgaGetIOAddress(fpga_handle handle, uint64_t wsid,
 		wrapped_handle->opae_handle, wsid, ioaddr);
 }
 
+fpga_result __OPAE_API__ fpgaBindSVA(fpga_handle handle, uint32_t *pasid)
+{
+	opae_wrapped_handle *wrapped_handle =
+		opae_validate_wrapped_handle(handle);
+
+	ASSERT_NOT_NULL(wrapped_handle);
+	// Unimplemented fpgaBindSVA() is acceptable. Return not supported.
+	if (!wrapped_handle->adapter_table->fpgaBindSVA)
+		return FPGA_NOT_SUPPORTED;
+
+	return wrapped_handle->adapter_table->fpgaBindSVA(
+		wrapped_handle->opae_handle, pasid);
+}
+
 fpga_result __OPAE_API__ fpgaGetOPAECVersion(fpga_version *version)
 {
 	ASSERT_NOT_NULL(version);

--- a/libraries/plugins/vfio/CMakeLists.txt
+++ b/libraries/plugins/vfio/CMakeLists.txt
@@ -48,5 +48,6 @@ opae_add_module_library(TARGET opae-v
 target_include_directories(opae-v
     PRIVATE
         ${OPAE_LIB_SOURCE}/libopae-c
+        ${OPAE_LIB_SOURCE}/plugins/xfpga
         ${uuid_INCLUDE}
 )

--- a/libraries/plugins/vfio/opae_vfio.c
+++ b/libraries/plugins/vfio/opae_vfio.c
@@ -51,6 +51,7 @@
 
 #include "opae_vfio.h"
 #include "dfl.h"
+#include "fpga-dfl.h"
 
 #include "opae_int.h"
 #include "props.h"
@@ -760,6 +761,13 @@ fpga_result __VFIO_API__ vfio_fpgaClose(fpga_handle handle)
 		opae_free(t);
 	} else {
 		OPAE_ERR("invalid token in handle");
+	}
+
+	if (h->sva_fd) {
+		// Release PASID and shared virtual addressing
+		opae_close(h->sva_fd);
+		h->sva_fd = 0;
+		h->pasid = 0;
 	}
 
 	close_vfio_pair(&h->vfio_pair);
@@ -1588,6 +1596,63 @@ fpga_result __VFIO_API__ vfio_fpgaGetIOAddress(fpga_handle handle,
 	*ioaddr = binfo->buffer_iova;
 
 	return FPGA_OK;
+}
+
+fpga_result __VFIO_API__ vfio_fpgaBindSVA(fpga_handle handle, uint32_t *pasid)
+{
+	vfio_handle *h;
+	char path[PATH_MAX];
+	int fd;
+	int err;
+	fpga_result res = FPGA_OK;
+
+	h = handle_check_and_lock(handle);
+	ASSERT_NOT_NULL(h);
+	ASSERT_NOT_NULL(pasid);
+
+	struct opae_vfio *v = h->vfio_pair->device;
+	if (!v || !v->cont_pciaddr) {
+		res = FPGA_NO_DRIVER;
+		goto out_unlock;
+	}
+
+	if (h->pasid) {
+		// vfio_fpgaBindSVA() was already called. Return the same result.
+		*pasid = h->pasid;
+		goto out_unlock;
+	}
+
+	// Currently, the dfl-pci driver provides support for allocating a PASID
+	// and binding it to the FPGA in the IOMMU. At some point, VFIO and the
+	// IOMMUFD will also support shared virtual addressing. When ready, this
+	// function can be updated to call libopaevfio.
+
+	// dfl-pci creates a device at /dev/dfl-pci-sva/<pci_addr> for all
+	// ports that support shared virtual memory. If the device isn't found
+	// then assume PASID is not supported, either by the host or the FPGA.
+	snprintf(path, sizeof(path), "/dev/dfl-pci-sva/%s", v->cont_pciaddr);
+	fd = opae_open(path, O_RDONLY);
+	if (fd > 0) {
+		// Request a shared virtual addressing. On success, the PASID is
+		// returned.
+		int res = opae_ioctl(fd, DFL_PCI_SVA_BIND_DEV);
+		if (res >= 0) {
+			// Success. Hold the file open. Closing the file would release
+			// the PASID and disable address sharing.
+			*pasid = res;
+			h->pasid = res;
+			h->sva_fd = fd;
+			goto out_unlock;
+		}
+		opae_close(fd);
+	}
+
+	res = FPGA_NOT_SUPPORTED;
+
+out_unlock:
+	opae_mutex_unlock(err, &h->lock);
+
+	return res;
 }
 
 fpga_result __VFIO_API__ vfio_fpgaCreateEventHandle(fpga_event_handle *event_handle)

--- a/libraries/plugins/vfio/opae_vfio.c
+++ b/libraries/plugins/vfio/opae_vfio.c
@@ -1638,7 +1638,7 @@ fpga_result __VFIO_API__ vfio_fpgaBindSVA(fpga_handle handle, uint32_t *pasid)
 	// then assume PASID is not supported, either by the host or the FPGA.
 	snprintf(path, sizeof(path), "/dev/dfl-pci-sva/%s", v->cont_pciaddr);
 	fd = opae_open(path, O_RDONLY);
-	if (fd > 0) {
+	if (fd >= 0) {
 		// Request a shared virtual addressing. On success, the PASID is
 		// returned.
 		int bind_pasid = opae_ioctl(fd, DFL_PCI_SVA_BIND_DEV);

--- a/libraries/plugins/vfio/opae_vfio.h
+++ b/libraries/plugins/vfio/opae_vfio.h
@@ -99,6 +99,8 @@ typedef struct _vfio_handle {
 	volatile uint8_t *mmio_base;
 	size_t mmio_size;
 	pthread_mutex_t lock;
+	int sva_fd;
+	int pasid;
 #define OPAE_FLAG_HAS_AVX512 (1u << 0)
 	uint32_t flags;
 } vfio_handle;

--- a/libraries/plugins/vfio/opae_vfio.h
+++ b/libraries/plugins/vfio/opae_vfio.h
@@ -102,6 +102,8 @@ typedef struct _vfio_handle {
 	int sva_fd;
 	int pasid;
 #define OPAE_FLAG_HAS_AVX512 (1u << 0)
+#define OPAE_FLAG_SVA_FD_VALID (1u << 1)  // Indicates sva_fd file handle is valid
+#define OPAE_FLAG_PASID_VALID (1u << 2)   // Indicates pasid is set
 	uint32_t flags;
 } vfio_handle;
 

--- a/libraries/plugins/vfio/plugin.c
+++ b/libraries/plugins/vfio/plugin.c
@@ -122,6 +122,8 @@ int __VFIO_API__ opae_plugin_configure(opae_api_adapter_table *adapter,
 		dlsym(adapter->plugin.dl_handle, "vfio_fpgaReleaseBuffer");
 	adapter->fpgaGetIOAddress =
 		dlsym(adapter->plugin.dl_handle, "vfio_fpgaGetIOAddress");
+	adapter->fpgaBindSVA =
+		dlsym(adapter->plugin.dl_handle, "vfio_fpgaBindSVA");
 	adapter->fpgaCreateEventHandle =
 		dlsym(adapter->plugin.dl_handle, "vfio_fpgaCreateEventHandle");
 	adapter->fpgaDestroyEventHandle =

--- a/libraries/plugins/xfpga/fpga-dfl.h
+++ b/libraries/plugins/xfpga/fpga-dfl.h
@@ -44,6 +44,7 @@
 #define DFL_FPGA_BASE 0
 #define DFL_PORT_BASE 0x40
 #define DFL_FME_BASE 0x80
+#define DFL_PCI_SVA_BASE 0xf8
 
 /* Common IOCTLs for both FME and AFU file descriptor */
 
@@ -169,7 +170,7 @@ struct dfl_fpga_port_dma_unmap {
  *
  * @start: Index of the first irq.
  * @count: The number of eventfd handler.
- * @evtfds: Eventfd handler.
+ * @evtfds: Eventfd handlers.
  */
 struct dfl_fpga_irq_set {
 	__u32 start;
@@ -288,5 +289,23 @@ struct dfl_fpga_fme_port_pr {
 #define DFL_FPGA_FME_ERR_SET_IRQ	_IOW(DFL_FPGA_MAGIC,	\
 					     DFL_FME_BASE + 4,	\
 					     struct dfl_fpga_irq_set)
+
+/**
+ * DFL_PCI_SVA_BIND_DEV - _IO(DFL_FPGA_MAGIC, DFL_PCI_SVA_BASE + 0)
+ *
+ * Ensure that a PASID is present in the user process and enable the
+ * PASID on the IOMMU domain of the device associated with the file handle.
+ * Returns the PASID on success, -errno on failure.
+ */
+#define DFL_PCI_SVA_BIND_DEV		_IO(DFL_FPGA_MAGIC,	\
+					     DFL_PCI_SVA_BASE + 0)
+
+/**
+ * DFL_PCI_SVA_UNBIND_DEV - _IO(DFL_FPGA_MAGIC,	DFL_PCI_SVA_BASE + 1)
+ *
+ * Unbind the current PASID from the device.
+ */
+#define DFL_PCI_SVA_UNBIND_DEV		_IO(DFL_FPGA_MAGIC,	\
+					    DFL_PCI_SVA_BASE + 1)
 
 #endif /* _UAPI_LINUX_FPGA_DFL_H */

--- a/tests/opae-c/dummy_plugin.c
+++ b/tests/opae-c/dummy_plugin.c
@@ -162,6 +162,7 @@ int __attribute__((visibility("default"))) opae_plugin_configure(opae_api_adapte
 	adapter->fpgaPrepareBuffer = NULL;
 	adapter->fpgaReleaseBuffer = NULL;
 	adapter->fpgaGetIOAddress = NULL;
+	adapter->fpgaBindSVA = NULL;
 	/*
 	**	adapter->fpgaGetOPAECVersion = NULL;
 	**	adapter->fpgaGetOPAECVersionString = NULL;


### PR DESCRIPTION
### Description
Add fpgaBindSVA() to allocate and bind PASIDs to FPGA ports. Shared virtual addressing requires hardware support, both in the CPU and on the FPGA.

fpgaBindSVA() depends on /dev/dfl-pci-sva from the dfl-pci driver. IOVA-based pinned DMA remains available with older drivers and hardware that does not support PASID.

OPAE behavior is unchanged when fpgaBindSVA() is not called.
### Collateral (docs, reports, design examples, case IDs):

- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
