### PR TITLE
Fix: vfio/uio test case bug

### DIFF
--- a/tests/opae-u/test_opae_uio_c.cpp
+++ b/tests/opae-u/test_opae_uio_c.cpp
@@ -3295,6 +3295,7 @@ TEST(opae_u, destroy_event_ok)
 
   ueh->magic = UIO_EVENT_HANDLE_MAGIC;
   ueh->lock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
+  ueh->fd = open("/dev/null", O_RDONLY);
 
   fpga_event_handle eh = ueh;
   EXPECT_EQ(0, uio_fpgaDestroyEventHandle(&eh));

--- a/tests/opae-v/test_opae_vfio_c.cpp
+++ b/tests/opae-v/test_opae_vfio_c.cpp
@@ -3241,6 +3241,7 @@ TEST(opae_v, destroy_event_ok)
 
   ueh->magic = VFIO_EVENT_HANDLE_MAGIC;
   ueh->lock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
+  ueh->fd = open("/dev/null", O_RDONLY);
 
   fpga_event_handle eh = ueh;
   EXPECT_EQ(0, vfio_fpgaDestroyEventHandle(&eh));


### PR DESCRIPTION
### Description
Fix for tests that were causing file descriptor 0 to be closed.


### Collateral (docs, reports, design examples, case IDs):


- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
vfio and uio plugin ULT's.