### PR TITLE
Feature: add fpgaBindSVA() support to C++ bindings

### DIFF
--- a/include/opae/cxx/core/handle.h
+++ b/include/opae/cxx/core/handle.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -186,11 +186,19 @@ class handle {
    */
   token::ptr_t get_token() const;
 
+  /** Bind IOMMU shared virtual addressing
+   *
+   * @return the non-zero process address space ID on success
+   * or zero on failure.
+   */
+  uint32_t bind_sva();
+
  private:
   handle(fpga_handle h);
 
   fpga_handle handle_;
   fpga_token token_;
+  uint32_t pasid_;
 };
 
 }  // end of namespace types

--- a/libraries/libopaecxx/src/handle.cpp
+++ b/libraries/libopaecxx/src/handle.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2021, Intel Corporation
+// Copyright(c) 2018-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -30,12 +30,13 @@
 #include <opae/manage.h>
 #include <opae/mmio.h>
 #include <opae/utils.h>
+#include <opae/buffer.h>
 
 namespace opae {
 namespace fpga {
 namespace types {
 
-handle::handle(fpga_handle h) : handle_(h), token_(nullptr) {}
+handle::handle(fpga_handle h) : handle_(h), token_(nullptr), pasid_(0) {}
 
 handle::~handle() {
   close();
@@ -127,6 +128,12 @@ uint8_t *handle::mmio_ptr(uint64_t offset, uint32_t csr_space) const {
 token::ptr_t handle::get_token() const {
   token::ptr_t p(new token(token_));
   return p;
+}
+
+uint32_t handle::bind_sva() {
+  if (!pasid_)
+    ASSERT_FPGA_OK(fpgaBindSVA(handle_, &pasid_));
+  return pasid_;
 }
 
 }  // end of namespace types

--- a/libraries/libopaecxx/src/handle.cpp
+++ b/libraries/libopaecxx/src/handle.cpp
@@ -23,6 +23,7 @@
 // CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
+#include <opae/buffer.h>
 #include <opae/cxx/core/except.h>
 #include <opae/cxx/core/handle.h>
 #include <opae/cxx/core/properties.h>
@@ -30,7 +31,6 @@
 #include <opae/manage.h>
 #include <opae/mmio.h>
 #include <opae/utils.h>
-#include <opae/buffer.h>
 
 namespace opae {
 namespace fpga {
@@ -131,8 +131,7 @@ token::ptr_t handle::get_token() const {
 }
 
 uint32_t handle::bind_sva() {
-  if (!pasid_)
-    ASSERT_FPGA_OK(fpgaBindSVA(handle_, &pasid_));
+  if (!pasid_) ASSERT_FPGA_OK(fpgaBindSVA(handle_, &pasid_));
   return pasid_;
 }
 

--- a/tests/opae-cxx/test_handle_cxx_core.cpp
+++ b/tests/opae-cxx/test_handle_cxx_core.cpp
@@ -1,4 +1,4 @@
-// Copyright(c) 2018-2022, Intel Corporation
+// Copyright(c) 2018-2023, Intel Corporation
 //
 // Redistribution  and  use  in source  and  binary  forms,  with  or  without
 // modification, are permitted provided that the following conditions are met:
@@ -169,6 +169,29 @@ TEST_P(handle_cxx_core, get_token) {
 
   token::ptr_t p;
   ASSERT_NO_THROW(p = tok->get_parent());
+}
+
+/**
+ * @test bind_sva
+ * Verify that handle::bind_sva can retrieve the pasid
+ * when supported.
+ */
+TEST_P(handle_cxx_core, bind_sva) {
+  handle_ = handle::open(tokens_[0], 0);
+  ASSERT_NE(nullptr, handle_.get());
+
+  uint32_t pasid = 0;
+  bool check_it = true; // only check if bind_sva is supported
+
+  try {
+    pasid = handle_->bind_sva();
+  } catch(opae::fpga::types::not_supported &ex) {
+    check_it = false;
+  }
+
+  if (check_it) {
+    ASSERT_NE(0, pasid);
+  }
 }
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(handle_cxx_core);


### PR DESCRIPTION
### Description
Adds C++ member function handle::bind_sva() which calls fpgaBindSVA() to perform the magic and retrieve the pasid.


### Collateral (docs, reports, design examples, case IDs):
N/A


- [X] Document Update Required? (Specify FIM/AFU/Scripts)
C Programming Guide

### Tests added:
handle_cxx_core.bind_sva

### Tests run:
CI