### PR TITLE
Fix: use -1 for invalid pasid

### DIFF
--- a/include/opae/buffer.h
+++ b/include/opae/buffer.h
@@ -139,7 +139,7 @@ fpga_result fpgaGetIOAddress(fpga_handle handle, uint64_t wsid,
  * Bind IOMMU shared virtual addressing
  *
  * When PCIe PASID, ATS and PRS capabilities are enabled, some platforms
- * supporting binding the IOMMU to user space virtual addresses.
+ * support binding the IOMMU to user space virtual addresses.
  *
  * @param[in]  handle   Handle to previously opened accelerator resource
  * @param[out] pasid    Process address space ID, set if not NULL.

--- a/libraries/libopaecxx/src/handle.cpp
+++ b/libraries/libopaecxx/src/handle.cpp
@@ -36,7 +36,8 @@ namespace opae {
 namespace fpga {
 namespace types {
 
-handle::handle(fpga_handle h) : handle_(h), token_(nullptr), pasid_(0) {}
+handle::handle(fpga_handle h)
+    : handle_(h), token_(nullptr), pasid_((uint32_t)-1) {}
 
 handle::~handle() {
   close();
@@ -131,7 +132,12 @@ token::ptr_t handle::get_token() const {
 }
 
 uint32_t handle::bind_sva() {
-  if (!pasid_) ASSERT_FPGA_OK(fpgaBindSVA(handle_, &pasid_));
+  if (pasid_ == (uint32_t)-1) {
+    auto res = fpgaBindSVA(handle_, &pasid_);
+    if (res != FPGA_NOT_SUPPORTED) {
+      ASSERT_FPGA_OK(res);
+    }
+  }
   return pasid_;
 }
 

--- a/libraries/plugins/vfio/opae_vfio.c
+++ b/libraries/plugins/vfio/opae_vfio.c
@@ -1608,9 +1608,6 @@ fpga_result __VFIO_API__ vfio_fpgaBindSVA(fpga_handle handle, uint32_t *pasid)
 	h = handle_check_and_lock(handle);
 	ASSERT_NOT_NULL(h);
 
-	if (pasid)
-		*pasid = -1;
-
 	struct opae_vfio *v = h->vfio_pair->device;
 	if (!v || !v->cont_pciaddr) {
 		res = FPGA_NO_DRIVER;

--- a/libraries/pyopae/pyhandle.cpp
+++ b/libraries/pyopae/pyhandle.cpp
@@ -181,6 +181,6 @@ const char *handle_doc_bind_sva() {
     Bind IOMMU shared virtual addressing.
     When PCIe PASID, ATS and PRS capabilities are enabled, some platforms
     support binding the IOMMU to user space virtual addresses.
-    Returns the non-zero PASID when supported, else 0.
+    Returns the PASID when supported, else (uint32_t)-1.
   )opaedoc";
 }

--- a/tests/opae-cxx/test_handle_cxx_core.cpp
+++ b/tests/opae-cxx/test_handle_cxx_core.cpp
@@ -180,7 +180,7 @@ TEST_P(handle_cxx_core, bind_sva) {
   handle_ = handle::open(tokens_[0], 0);
   ASSERT_NE(nullptr, handle_.get());
 
-  uint32_t pasid = 0;
+  uint32_t pasid = (uint32_t)-1;
   bool check_it = true; // only check if bind_sva is supported
 
   try {
@@ -190,7 +190,7 @@ TEST_P(handle_cxx_core, bind_sva) {
   }
 
   if (check_it) {
-    ASSERT_NE(0, pasid);
+    ASSERT_NE((uint32_t)-1, pasid);
   }
 }
 


### PR DESCRIPTION
### Description
Don't use 0 to describe an invalid pasid. Valid pasid values are unsigned 20-bit integers.
Use (uint32_t)-1 for invalid pasid.


### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
$ python3
>>> import opae.fpga
>>> props = opae.fpga.properties(type=opae.fpga.ACCELERATOR)
>>> tokens = opae.fpga.enumerate([props])
>>> h = opae.fpga.open(tokens[0])
>>> print(h.bind_sva())