### PR TITLE
Update: add --exclude option to pci_device unplug

### DIFF
--- a/python/opae.admin/opae/admin/sysfs.py
+++ b/python/opae.admin/opae/admin/sysfs.py
@@ -239,6 +239,23 @@ class pci_node(sysfs_node):
     def __repr__(self):
         return str(self)
 
+    def __eq__(self, other):
+        return self._pci_address['pci_address'] == other._pci_address['pci_address']
+
+    @staticmethod
+    def pre_order_traverse(node, ex, visit):
+        if node not in ex:
+            visit(node)
+        for c in node.children:
+            pci_node.pre_order_traverse(c, ex, visit)
+
+    @staticmethod
+    def post_order_traverse(node, ex, visit):
+        for c in node.children:
+            pci_node.post_order_traverse(c, ex, visit)
+        if node not in ex:
+            visit(node)
+
     def _find_children(self):
         children = []
         for f in os.listdir(self.sysfs_path):

--- a/python/opae.admin/opae/admin/tools/pci_device.py
+++ b/python/opae.admin/opae/admin/tools/pci_device.py
@@ -215,8 +215,8 @@ class unplug(object):
         debug = args.debug
 
         exclude_node = None
-        if myargs.exclude:
-            exclude_devs = pcie_device.enum(myargs.exclude)
+        if args.exclude:
+            exclude_devs = pcie_device.enum(args.exclude)
             if exclude_devs:
                 exclude_node = exclude_devs[0].pci_node
 

--- a/python/opae.admin/opae/admin/version.py
+++ b/python/opae.admin/opae/admin/version.py
@@ -34,7 +34,7 @@ except ImportError:
 version = {
     'major': 1,
     'minor': 4,
-    'patch': 3
+    'patch': 5
 }
 
 

--- a/python/opae.admin/opae/admin/version.py
+++ b/python/opae.admin/opae/admin/version.py
@@ -1,4 +1,4 @@
-# Copyright(c) 2020-2022, Intel Corporation
+# Copyright(c) 2020-2023, Intel Corporation
 #
 # Redistribution  and  use  in source  and  binary  forms,  with  or  without
 # modification, are permitted provided that the following conditions are met:
@@ -34,7 +34,7 @@ except ImportError:
 version = {
     'major': 1,
     'minor': 4,
-    'patch': 5
+    'patch': 6
 }
 
 

--- a/python/opae.admin/pyproject.toml
+++ b/python/opae.admin/pyproject.toml
@@ -30,7 +30,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opae.admin"
-version = "1.4.5"
+version = "1.4.6"
 description = "opae.admin provides Python classes for interfacing with OPAE kernel drivers"
 #readme = ""
 license = {text = "BSD-3-Clause"}

--- a/python/opae.admin/pyproject.toml
+++ b/python/opae.admin/pyproject.toml
@@ -30,7 +30,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opae.admin"
-version = "1.4.4"
+version = "1.4.5"
 description = "opae.admin provides Python classes for interfacing with OPAE kernel drivers"
 #readme = ""
 license = {text = "BSD-3-Clause"}
@@ -60,5 +60,6 @@ pci_device = "opae.admin.tools.pci_device:main"
 regmap-debugfs = "opae.admin.tools.regmap_debugfs:main"
 fpgareg = "opae.admin.tools.fpgareg:main"
 n5010tool = "opae.admin.tools.n5010tool:main"
+
 [project.urls]
 Homepage = "https://opae.github.io"

--- a/python/opae.admin/setup.py
+++ b/python/opae.admin/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='opae.admin',
-    version='1.4.5',
+    version='1.4.6',
     packages=find_namespace_packages(include=['opae.*']),
     entry_points={
         'console_scripts': [

--- a/python/opae.admin/setup.py
+++ b/python/opae.admin/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='opae.admin',
-    version='1.4.4',
+    version='1.4.5',
     packages=find_namespace_packages(include=['opae.*']),
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
### Description
In a hw design utilizing two PFs, the unplug command must provide an option to preserve
the PF that provides the PR capability; otherwise, PR will not function.


### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
Manual verification of --exclude functionality.