### PR TITLE
Fix: Update HE Cache  bias command line input

### DIFF
--- a/samples/cxl_host_exerciser/cxl_he_cache_cmd.h
+++ b/samples/cxl_host_exerciser/cxl_he_cache_cmd.h
@@ -50,8 +50,8 @@ class he_cache_cmd : public he_cmd {
 public:
   he_cache_cmd()
       : he_continuousmode_(false), he_contmodetime_(0), he_linerep_count_(0),
-        he_stide_(0), he_test_(0), he_test_all_(false), he_dev_instance_(0),
-        he_stide_cmd_(false) {}
+        he_stride_(0), he_test_(0), he_test_all_(false), he_dev_instance_(0),
+        he_stride_cmd_(false) {}
 
   virtual ~he_cache_cmd() {}
 
@@ -107,7 +107,7 @@ public:
         ->default_val("/dev/dfl-cxl-cache.0");
 
     // Set sride
-    app->add_option("--stride", he_stide_, "Set stride value")
+    app->add_option("--stride", he_stride_, "Set stride value")
         ->transform(CLI::Range(0, 3))->default_val("0");
 
     // Line repeat count
@@ -153,9 +153,9 @@ public:
 
     // set RD_ADDR_TABLE_CTRL
     rd_table_ctl_.value = 0;
-    if (he_stide_cmd_) {
+    if (he_stride_cmd_) {
         rd_table_ctl_.enable_address_stride = 1;
-        rd_table_ctl_.stride = he_stide_;
+        rd_table_ctl_.stride = he_stride_;
     } else {
         // Set Stride to 3 for FPGA read/write cache hit/miss
         rd_table_ctl_.enable_address_stride = 1;
@@ -202,9 +202,9 @@ public:
 
     // set RD_ADDR_TABLE_CTRL
     rd_table_ctl_.value = 0;
-    if (he_stide_cmd_) {
+    if (he_stride_cmd_) {
         rd_table_ctl_.enable_address_stride = 1;
-        rd_table_ctl_.stride = he_stide_;
+        rd_table_ctl_.stride = he_stride_;
     } else {
         // Set Stride to 3 for FPGA read/write cache hit/miss
         rd_table_ctl_.enable_address_stride = 1;
@@ -269,9 +269,9 @@ public:
 
     // set RD_ADDR_TABLE_CTRL
     rd_table_ctl_.value = 0;
-    if (he_stide_cmd_) {
+    if (he_stride_cmd_) {
         rd_table_ctl_.enable_address_stride = 1;
-        rd_table_ctl_.stride = he_stide_;
+        rd_table_ctl_.stride = he_stride_;
     } else {
         // Set Stride to 3 for FPGA read/write cache hit/miss
         rd_table_ctl_.enable_address_stride = 1;
@@ -324,9 +324,9 @@ public:
 
     // Set WR_ADDR_TABLE_CTRL
     wr_table_ctl_.value = 0;
-    if (he_stide_cmd_) {
+    if (he_stride_cmd_) {
         wr_table_ctl_.enable_address_stride = 1;
-        wr_table_ctl_.stride = he_stide_;
+        wr_table_ctl_.stride = he_stride_;
     } else {
         // Set Stride to 3 for FPGA read/write cache hit/miss
         wr_table_ctl_.enable_address_stride = 1;
@@ -388,9 +388,9 @@ public:
 
     // set RD_ADDR_TABLE_CTRL
     rd_table_ctl_.value = 0;
-    if (he_stide_cmd_) {
+    if (he_stride_cmd_) {
         rd_table_ctl_.enable_address_stride = 1;
-        rd_table_ctl_.stride = he_stide_;
+        rd_table_ctl_.stride = he_stride_;
     } else {
         // Set Stride to 3 for FPGA read/write cache hit/miss
         rd_table_ctl_.enable_address_stride = 1;
@@ -464,9 +464,9 @@ public:
 
     // Set WR_ADDR_TABLE_CTRL
     wr_table_ctl_.value = 0;
-    if (he_stide_cmd_) {
+    if (he_stride_cmd_) {
         wr_table_ctl_.enable_address_stride = 1;
-        wr_table_ctl_.stride = he_stide_;
+        wr_table_ctl_.stride = he_stride_;
     } else {
         // Set Stride to 3 for FPGA read/write cache hit/miss
         wr_table_ctl_.enable_address_stride = 1;
@@ -540,9 +540,9 @@ public:
 
     // set RD_ADDR_TABLE_CTRL
     rd_table_ctl_.value = 0;
-    if (he_stide_cmd_) {
+    if (he_stride_cmd_) {
         rd_table_ctl_.enable_address_stride = 1;
-        rd_table_ctl_.stride = he_stide_;
+        rd_table_ctl_.stride = he_stride_;
     }
     host_exe_->write64(HE_RD_ADDR_TABLE_CTRL, rd_table_ctl_.value);
 
@@ -624,9 +624,9 @@ public:
 
     // set RD_ADDR_TABLE_CTRL
     wr_table_ctl_.value = 0;
-    if (he_stide_cmd_) {
+    if (he_stride_cmd_) {
         wr_table_ctl_.enable_address_stride = 1;
-        wr_table_ctl_.stride = he_stide_;
+        wr_table_ctl_.stride = he_stride_;
     }
     host_exe_->write64(HE_WR_ADDR_TABLE_CTRL, wr_table_ctl_.value);
 
@@ -705,9 +705,9 @@ public:
 
     // set RD_ADDR_TABLE_CTR
     rd_table_ctl_.value = 0;
-    if (he_stide_cmd_) {
+    if (he_stride_cmd_) {
         rd_table_ctl_.enable_address_stride = 1;
-        rd_table_ctl_.stride = he_stide_;
+        rd_table_ctl_.stride = he_stride_;
     }
     host_exe_->write64(HE_RD_ADDR_TABLE_CTRL, rd_table_ctl_.value);
 
@@ -778,9 +778,9 @@ public:
 
     // set RD_ADDR_TABLE_CTR
     wr_table_ctl_.value = 0;
-    if (he_stide_cmd_) {
+    if (he_stride_cmd_) {
         wr_table_ctl_.enable_address_stride = 1;
-        wr_table_ctl_.stride = he_stide_;
+        wr_table_ctl_.stride = he_stride_;
     }
     host_exe_->write64(HE_WR_ADDR_TABLE_CTRL, rd_table_ctl_.value);
 
@@ -833,7 +833,7 @@ public:
 
     CLI::Option* opt = app->get_option_no_throw("--stride");
     if (opt && opt->count() == 1) {
-        he_stide_cmd_ = true;
+        he_stride_cmd_ = true;
     }
 
     // reset HE cache
@@ -937,11 +937,11 @@ protected:
   bool he_continuousmode_;
   uint32_t he_contmodetime_;
   uint32_t he_linerep_count_;
-  uint32_t he_stide_;
+  uint32_t he_stride_;
   uint32_t he_test_;
   bool he_test_all_;
   uint32_t he_dev_instance_;
-  bool he_stide_cmd_;
+  bool he_stride_cmd_;
 };
 
 void he_cache_thread(uint8_t *buf_ptr, uint64_t len) {

--- a/samples/cxl_host_exerciser/cxl_he_cache_cmd.h
+++ b/samples/cxl_host_exerciser/cxl_he_cache_cmd.h
@@ -50,7 +50,8 @@ class he_cache_cmd : public he_cmd {
 public:
   he_cache_cmd()
       : he_continuousmode_(false), he_contmodetime_(0), he_linerep_count_(0),
-        he_stide_(0), he_test_(0), he_test_all_(false), he_dev_instance_(0) {}
+        he_stide_(0), he_test_(0), he_test_all_(false), he_dev_instance_(0),
+        he_stide_cmd_(false) {}
 
   virtual ~he_cache_cmd() {}
 
@@ -94,9 +95,9 @@ public:
         ->default_val("host");
 
     app->add_option("--bias", he_bias_,
-        "host exerciser run on hostmem or fpgamem")
+        "host exerciser run on host or device")
         ->transform(CLI::CheckedTransformer(he_bias))
-        ->default_val("hostmem");
+        ->default_val("host");
 
     // device cache0 or cache1
     app->add_option("--device", he_dev_instance_,
@@ -138,9 +139,6 @@ public:
     he_info_.value = host_exe_->read64(HE_INFO);
     host_exe_->write64(HE_RD_NUM_LINES, FPGA_512CACHE_LINES);
 
-    // Set Stride to 3 for FPGA read/write cache hit/miss
-    he_stide_ = 3;
-
     cout << "Read number Lines:" << FPGA_512CACHE_LINES << endl;
     cout << "Line Repeat Count:" << he_linerep_count_ << endl;
     cout << "Read address table size:" << he_info_.read_addr_table_size << endl;
@@ -155,9 +153,13 @@ public:
 
     // set RD_ADDR_TABLE_CTRL
     rd_table_ctl_.value = 0;
-    if (he_stide_ > 0) {
+    if (he_stide_cmd_) {
         rd_table_ctl_.enable_address_stride = 1;
         rd_table_ctl_.stride = he_stide_;
+    } else {
+        // Set Stride to 3 for FPGA read/write cache hit/miss
+        rd_table_ctl_.enable_address_stride = 1;
+        rd_table_ctl_.stride = 3;
     }
     host_exe_->write64(HE_RD_ADDR_TABLE_CTRL, rd_table_ctl_.value);
 
@@ -178,7 +180,7 @@ public:
     he_start_test();
 
     // wait for completion
-    if (!he_wait_test_completion()) {
+    if (!he_wait_test_completion(HE_PRTEST_SCENARIO)) {
       he_perf_counters();
       host_exerciser_errors();
       host_exe_->free_cache_read();
@@ -200,9 +202,13 @@ public:
 
     // set RD_ADDR_TABLE_CTRL
     rd_table_ctl_.value = 0;
-    if (he_stide_ > 0) {
+    if (he_stide_cmd_) {
         rd_table_ctl_.enable_address_stride = 1;
         rd_table_ctl_.stride = he_stide_;
+    } else {
+        // Set Stride to 3 for FPGA read/write cache hit/miss
+        rd_table_ctl_.enable_address_stride = 1;
+        rd_table_ctl_.stride = 3;
     }
     host_exe_->write64(HE_RD_ADDR_TABLE_CTRL, rd_table_ctl_.value);
 
@@ -248,9 +254,6 @@ public:
     he_info_.value = host_exe_->read64(HE_INFO);
     host_exe_->write64(HE_RD_NUM_LINES, FPGA_512CACHE_LINES);
 
-    // Set Stride to 3 for FPGA read/write cache hit/miss
-    he_stide_ = 3;
-
     cout << "Read/write number Lines:" << FPGA_512CACHE_LINES << endl;
     cout << "Line Repeat Count:" << he_linerep_count_ << endl;
     cout << "Read address table size:" << he_info_.read_addr_table_size << endl;
@@ -266,9 +269,13 @@ public:
 
     // set RD_ADDR_TABLE_CTRL
     rd_table_ctl_.value = 0;
-    if (he_stide_ > 0) {
+    if (he_stide_cmd_) {
         rd_table_ctl_.enable_address_stride = 1;
         rd_table_ctl_.stride = he_stide_;
+    } else {
+        // Set Stride to 3 for FPGA read/write cache hit/miss
+        rd_table_ctl_.enable_address_stride = 1;
+        rd_table_ctl_.stride = 3;
     }
     host_exe_->write64(HE_RD_ADDR_TABLE_CTRL, rd_table_ctl_.value);
 
@@ -289,7 +296,7 @@ public:
     he_start_test();
 
     // wait for completion
-    if (!he_wait_test_completion()) {
+    if (!he_wait_test_completion(HE_PRTEST_SCENARIO)) {
       he_perf_counters();
       host_exerciser_errors();
       host_exe_->free_cache_read_write();
@@ -317,9 +324,13 @@ public:
 
     // Set WR_ADDR_TABLE_CTRL
     wr_table_ctl_.value = 0;
-    if (he_stide_ > 0) {
+    if (he_stide_cmd_) {
         wr_table_ctl_.enable_address_stride = 1;
         wr_table_ctl_.stride = he_stide_;
+    } else {
+        // Set Stride to 3 for FPGA read/write cache hit/miss
+        wr_table_ctl_.enable_address_stride = 1;
+        wr_table_ctl_.stride = 3;
     }
     host_exe_->write64(HE_WR_ADDR_TABLE_CTRL, wr_table_ctl_.value);
     host_exe_->write64(HE_WR_NUM_LINES, FPGA_512CACHE_LINES);
@@ -364,9 +375,6 @@ public:
     he_info_.value = host_exe_->read64(HE_INFO);
     host_exe_->write64(HE_RD_NUM_LINES, FPGA_512CACHE_LINES);
 
-    // Set Stride to 3 for FPGA read/write cache hit/miss
-    he_stide_ = 3;
-
     cout << "Read number Lines:" << FPGA_512CACHE_LINES << endl;
     cout << "Line Repeat Count:" << he_linerep_count_ << endl;
     cout << "Read address table size:" << he_info_.read_addr_table_size << endl;
@@ -380,9 +388,13 @@ public:
 
     // set RD_ADDR_TABLE_CTRL
     rd_table_ctl_.value = 0;
-    if (he_stide_ > 0) {
+    if (he_stide_cmd_) {
         rd_table_ctl_.enable_address_stride = 1;
         rd_table_ctl_.stride = he_stide_;
+    } else {
+        // Set Stride to 3 for FPGA read/write cache hit/miss
+        rd_table_ctl_.enable_address_stride = 1;
+        rd_table_ctl_.stride = 3;
     }
     host_exe_->write64(HE_RD_ADDR_TABLE_CTRL, rd_table_ctl_.value);
 
@@ -437,9 +449,6 @@ public:
     he_info_.value = host_exe_->read64(HE_INFO);
     host_exe_->write64(HE_WR_NUM_LINES, FPGA_512CACHE_LINES);
 
-    // Set Stride to 3 for FPGA read/write cache hit/miss
-    he_stide_ = 0x3;
-
     cout << "Read/write number Lines:" << FPGA_512CACHE_LINES << endl;
     cout << "Line Repeat Count:" << he_linerep_count_ << endl;
     cout << "Read address table size:" << he_info_.read_addr_table_size << endl;
@@ -455,9 +464,13 @@ public:
 
     // Set WR_ADDR_TABLE_CTRL
     wr_table_ctl_.value = 0;
-    if (he_stide_ > 0) {
+    if (he_stide_cmd_) {
         wr_table_ctl_.enable_address_stride = 1;
         wr_table_ctl_.stride = he_stide_;
+    } else {
+        // Set Stride to 3 for FPGA read/write cache hit/miss
+        wr_table_ctl_.enable_address_stride = 1;
+        wr_table_ctl_.stride = 3;
     }
     host_exe_->write64(HE_WR_ADDR_TABLE_CTRL, wr_table_ctl_.value);
 
@@ -527,7 +540,7 @@ public:
 
     // set RD_ADDR_TABLE_CTRL
     rd_table_ctl_.value = 0;
-    if (he_stide_ > 0) {
+    if (he_stide_cmd_) {
         rd_table_ctl_.enable_address_stride = 1;
         rd_table_ctl_.stride = he_stide_;
     }
@@ -611,7 +624,7 @@ public:
 
     // set RD_ADDR_TABLE_CTRL
     wr_table_ctl_.value = 0;
-    if (he_stide_ > 0) {
+    if (he_stide_cmd_) {
         wr_table_ctl_.enable_address_stride = 1;
         wr_table_ctl_.stride = he_stide_;
     }
@@ -692,7 +705,7 @@ public:
 
     // set RD_ADDR_TABLE_CTR
     rd_table_ctl_.value = 0;
-    if (he_stide_ > 0) {
+    if (he_stide_cmd_) {
         rd_table_ctl_.enable_address_stride = 1;
         rd_table_ctl_.stride = he_stide_;
     }
@@ -765,7 +778,7 @@ public:
 
     // set RD_ADDR_TABLE_CTR
     wr_table_ctl_.value = 0;
-    if (he_stide_ > 0) {
+    if (he_stide_cmd_) {
         wr_table_ctl_.enable_address_stride = 1;
         wr_table_ctl_.stride = he_stide_;
     }
@@ -818,6 +831,11 @@ public:
       cout << "numa nodes are available set numa node to 0" << endl;
     };
 
+    CLI::Option* opt = app->get_option_no_throw("--stride");
+    if (opt && opt->count() == 1) {
+        he_stide_cmd_ = true;
+    }
+
     // reset HE cache
     he_ctl_.value = 0;
     he_ctl_.ResetL = 0;
@@ -827,6 +845,10 @@ public:
     host_exe_->write64(HE_CTL, he_ctl_.value);
 
     print_csr();
+
+    if (!he_set_bias_mode()) {
+        return -1;
+    }
 
     if (he_test_all_ == true) {
       int retvalue = 0;
@@ -919,6 +941,7 @@ protected:
   uint32_t he_test_;
   bool he_test_all_;
   uint32_t he_dev_instance_;
+  bool he_stide_cmd_;
 };
 
 void he_cache_thread(uint8_t *buf_ptr, uint64_t len) {

--- a/samples/cxl_host_exerciser/cxl_he_cache_cmd.h
+++ b/samples/cxl_host_exerciser/cxl_he_cache_cmd.h
@@ -156,10 +156,13 @@ public:
     if (he_stride_cmd_) {
         rd_table_ctl_.enable_address_stride = 1;
         rd_table_ctl_.stride = he_stride_;
-    } else {
-        // Set Stride to 3 for FPGA read/write cache hit/miss
+    } else if (he_target_ == HE_TARGET_FPGA) {
+        // Set Stride to 3 for Target FPGA Memory
         rd_table_ctl_.enable_address_stride = 1;
         rd_table_ctl_.stride = 3;
+    } else {
+        rd_table_ctl_.enable_address_stride = 1;
+        rd_table_ctl_.stride = he_stride_;
     }
     host_exe_->write64(HE_RD_ADDR_TABLE_CTRL, rd_table_ctl_.value);
 
@@ -205,10 +208,13 @@ public:
     if (he_stride_cmd_) {
         rd_table_ctl_.enable_address_stride = 1;
         rd_table_ctl_.stride = he_stride_;
-    } else {
-        // Set Stride to 3 for FPGA read/write cache hit/miss
+    } else if (he_target_ == HE_TARGET_FPGA) {
+        // Set Stride to 3 for Target FPGA Memory
         rd_table_ctl_.enable_address_stride = 1;
         rd_table_ctl_.stride = 3;
+    } else {
+        rd_table_ctl_.enable_address_stride = 1;
+        rd_table_ctl_.stride = he_stride_;
     }
     host_exe_->write64(HE_RD_ADDR_TABLE_CTRL, rd_table_ctl_.value);
 
@@ -272,10 +278,13 @@ public:
     if (he_stride_cmd_) {
         rd_table_ctl_.enable_address_stride = 1;
         rd_table_ctl_.stride = he_stride_;
-    } else {
-        // Set Stride to 3 for FPGA read/write cache hit/miss
+    } else if (he_target_ == HE_TARGET_FPGA) {
+        // Set Stride to 3 for Target FPGA Memory
         rd_table_ctl_.enable_address_stride = 1;
         rd_table_ctl_.stride = 3;
+    } else {
+        rd_table_ctl_.enable_address_stride = 1;
+        rd_table_ctl_.stride = he_stride_;
     }
     host_exe_->write64(HE_RD_ADDR_TABLE_CTRL, rd_table_ctl_.value);
 
@@ -327,10 +336,13 @@ public:
     if (he_stride_cmd_) {
         wr_table_ctl_.enable_address_stride = 1;
         wr_table_ctl_.stride = he_stride_;
-    } else {
-        // Set Stride to 3 for FPGA read/write cache hit/miss
+    } else if (he_target_ == HE_TARGET_FPGA) {
+        // Set Stride to 3 for Target FPGA Memory
         wr_table_ctl_.enable_address_stride = 1;
         wr_table_ctl_.stride = 3;
+    } else {
+        wr_table_ctl_.enable_address_stride = 1;
+        wr_table_ctl_.stride = he_stride_;
     }
     host_exe_->write64(HE_WR_ADDR_TABLE_CTRL, wr_table_ctl_.value);
     host_exe_->write64(HE_WR_NUM_LINES, FPGA_512CACHE_LINES);
@@ -391,10 +403,13 @@ public:
     if (he_stride_cmd_) {
         rd_table_ctl_.enable_address_stride = 1;
         rd_table_ctl_.stride = he_stride_;
-    } else {
-        // Set Stride to 3 for FPGA read/write cache hit/miss
+    } else if (he_target_ == HE_TARGET_FPGA) {
+        // Set Stride to 3 for Target FPGA Memory
         rd_table_ctl_.enable_address_stride = 1;
         rd_table_ctl_.stride = 3;
+    } else {
+        rd_table_ctl_.enable_address_stride = 1;
+        rd_table_ctl_.stride = he_stride_;
     }
     host_exe_->write64(HE_RD_ADDR_TABLE_CTRL, rd_table_ctl_.value);
 
@@ -467,10 +482,13 @@ public:
     if (he_stride_cmd_) {
         wr_table_ctl_.enable_address_stride = 1;
         wr_table_ctl_.stride = he_stride_;
-    } else {
-        // Set Stride to 3 for FPGA read/write cache hit/miss
+    } else if (he_target_ == HE_TARGET_FPGA) {
+        // Set Stride to 3 for Target FPGA Memory
         wr_table_ctl_.enable_address_stride = 1;
         wr_table_ctl_.stride = 3;
+    } else {
+        wr_table_ctl_.enable_address_stride = 1;
+        wr_table_ctl_.stride = he_stride_;
     }
     host_exe_->write64(HE_WR_ADDR_TABLE_CTRL, wr_table_ctl_.value);
 
@@ -540,10 +558,8 @@ public:
 
     // set RD_ADDR_TABLE_CTRL
     rd_table_ctl_.value = 0;
-    if (he_stride_cmd_) {
-        rd_table_ctl_.enable_address_stride = 1;
-        rd_table_ctl_.stride = he_stride_;
-    }
+    rd_table_ctl_.enable_address_stride = 1;
+    rd_table_ctl_.stride = he_stride_;
     host_exe_->write64(HE_RD_ADDR_TABLE_CTRL, rd_table_ctl_.value);
 
     // Allocate DSM buffer
@@ -624,10 +640,8 @@ public:
 
     // set RD_ADDR_TABLE_CTRL
     wr_table_ctl_.value = 0;
-    if (he_stride_cmd_) {
-        wr_table_ctl_.enable_address_stride = 1;
-        wr_table_ctl_.stride = he_stride_;
-    }
+    wr_table_ctl_.enable_address_stride = 1;
+    wr_table_ctl_.stride = he_stride_;
     host_exe_->write64(HE_WR_ADDR_TABLE_CTRL, wr_table_ctl_.value);
 
     // Allocate DSM buffer
@@ -705,10 +719,8 @@ public:
 
     // set RD_ADDR_TABLE_CTR
     rd_table_ctl_.value = 0;
-    if (he_stride_cmd_) {
-        rd_table_ctl_.enable_address_stride = 1;
-        rd_table_ctl_.stride = he_stride_;
-    }
+    rd_table_ctl_.enable_address_stride = 1;
+    rd_table_ctl_.stride = he_stride_;
     host_exe_->write64(HE_RD_ADDR_TABLE_CTRL, rd_table_ctl_.value);
 
     // Allocate DSM buffer
@@ -778,10 +790,8 @@ public:
 
     // set RD_ADDR_TABLE_CTR
     wr_table_ctl_.value = 0;
-    if (he_stride_cmd_) {
-        wr_table_ctl_.enable_address_stride = 1;
-        wr_table_ctl_.stride = he_stride_;
-    }
+    wr_table_ctl_.enable_address_stride = 1;
+    wr_table_ctl_.stride = he_stride_;
     host_exe_->write64(HE_WR_ADDR_TABLE_CTRL, rd_table_ctl_.value);
 
     // Allocate DSM buffer

--- a/samples/cxl_host_exerciser/cxl_he_cache_cmd.h
+++ b/samples/cxl_host_exerciser/cxl_he_cache_cmd.h
@@ -95,7 +95,7 @@ public:
         ->default_val("host");
 
     app->add_option("--bias", he_bias_,
-        "host exerciser run on host or device")
+        "CXL IP memory access Bias mode: host or device")
         ->transform(CLI::CheckedTransformer(he_bias))
         ->default_val("host");
 

--- a/samples/cxl_host_exerciser/cxl_he_cmd.h
+++ b/samples/cxl_host_exerciser/cxl_he_cmd.h
@@ -251,8 +251,7 @@ public:
         if (he_bias_ == HOSTMEM_BIAS) {
             he_ctl_.bias_support = HOSTMEM_BIAS;
         } else {
-            cerr << "Invalid configuration:Target memory host and bias device"
-                << endl;
+            cerr << "Wrong BIAS mode for specified target memory type" << endl;
             return false;
         }
     } else {

--- a/samples/cxl_host_exerciser/cxl_host_exerciser.h
+++ b/samples/cxl_host_exerciser/cxl_host_exerciser.h
@@ -334,9 +334,8 @@ const std::map<std::string, uint32_t> he_targets = {
 
 // Bias support
 const std::map<std::string, uint32_t> he_bias = {
-    {"hostmem", HOSTMEM_BIAS},
-    {"fpgamem_host_bias", FPGAMEM_HOST_BIAS},
-    {"fpgamem_device_bias", FPGAMEM_DEVICE_BIAS},
+    {"host", HOSTMEM_BIAS},
+    {"device", FPGAMEM_DEVICE_BIAS},
 };
 
 // he cxl cache device instance

--- a/samples/cxl_host_exerciser/he_cache_test.h
+++ b/samples/cxl_host_exerciser/he_cache_test.h
@@ -456,7 +456,7 @@ public:
     logger_->set_level(spdlog::level::from_str(log_level_));
     current_command_ = test;
     if (find_dev_feature() != 0) {
-      cerr << "fails to find feature" << endl;
+      cerr << "Failed to find feature" << endl;
       return exit_codes::exception;
     };
 
@@ -536,7 +536,7 @@ public:
     memset(&dma_map, 0, sizeof(dma_map));
 
     if (!buffer_allocate(&ptr, len, numa_node)) {
-        cerr << "Fails to allocate 4k huge page:" << strerror(errno) << endl;
+        cerr << "Failed to allocate 4k huge page:" << strerror(errno) << endl;
         return false;
     }
 
@@ -610,7 +610,7 @@ public:
     memset(&dma_map, 0, sizeof(dma_map));
 
     if (!buffer_allocate(&ptr, len, numa_node)) {
-        cerr << "Fails to allocate 2MB huge page:" << strerror(errno) << endl;
+        cerr << "Failed to allocate 2MB huge page:" << strerror(errno) << endl;
         return false;
     }
     cout << "Read buffer numa node: " << numa_node << endl;
@@ -678,7 +678,7 @@ public:
 
     memset(&dma_map, 0, sizeof(dma_map));
     if (!buffer_allocate(&ptr, len, numa_node)) {
-        cerr << "Fails to allocate 2MB huge page:" << strerror(errno) << endl;
+        cerr << "Failed to allocate 2MB huge page:" << strerror(errno) << endl;
         return false;
     }
 
@@ -746,7 +746,7 @@ public:
 
     memset(&dma_map, 0, sizeof(dma_map));
     if (!buffer_allocate(&ptr, len, numa_node)) {
-        cerr << "Fails to allocate 2MB huge page:" << strerror(errno) << endl;
+        cerr << "Failed to allocate 2MB huge page:" << strerror(errno) << endl;
         return false;
     }
     cout << "Read/Write buffer numa node: " << numa_node << endl;


### PR DESCRIPTION
-Change HE Cache  bias command line to –bias host or device 
-Change scenario  setup message  to “Pretest scenario started..”  and  actual test message Test started ......"
-Change Fails to allocate 2MB huge page: Invalid argument to “Failed to allocate 2MB huge page: Invalid argument”
-Fix  output message “number of nodes on system”
-Set Stride value only if user passes command line  --stride value.
