### PR TITLE
Fix: remove problematic pip option --no-warn-script-location

### DIFF
--- a/binaries/fpgadiag/CMakeLists.txt
+++ b/binaries/fpgadiag/CMakeLists.txt
@@ -112,7 +112,7 @@ if (OPAE_WITH_PYBIND11)
 
     add_custom_command(
         OUTPUT ${OUTPUT}
-        COMMAND ${Python3_EXECUTABLE} -m pip install --root=${PYDIST_STAGE_DIR}/build --no-warn-script-location .
+        COMMAND ${Python3_EXECUTABLE} -m pip install --root=${PYDIST_STAGE_DIR}/build .
         COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
         WORKING_DIRECTORY ${PYDIST_STAGE_DIR}
         DEPENDS pyproject.toml setup.py ${PKG_FILES}

--- a/binaries/hssi/CMakeLists.txt
+++ b/binaries/hssi/CMakeLists.txt
@@ -29,7 +29,7 @@ file(GLOB_RECURSE PKG_FILES ${CMAKE_CURRENT_SOURCE_DIR}/ethernet/*.py)
 
 add_custom_command(
     OUTPUT ${OUTPUT}
-    COMMAND ${Python3_EXECUTABLE} -m pip install --root=${CMAKE_CURRENT_SOURCE_DIR}/build --no-warn-script-location .
+    COMMAND ${Python3_EXECUTABLE} -m pip install --root=${CMAKE_CURRENT_SOURCE_DIR}/build .
     COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS pyproject.toml ${PKG_FILES}

--- a/binaries/ofs.uio/CMakeLists.txt
+++ b/binaries/ofs.uio/CMakeLists.txt
@@ -28,7 +28,7 @@ set(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/timestamp)
 
 add_custom_command(
     OUTPUT ${OUTPUT}
-    COMMAND ${Python3_EXECUTABLE} -m pip install --root=${CMAKE_CURRENT_SOURCE_DIR}/build --no-warn-script-location .
+    COMMAND ${Python3_EXECUTABLE} -m pip install --root=${CMAKE_CURRENT_SOURCE_DIR}/build .
     COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS pyproject.toml ${PKG_FILES}

--- a/cmake/modules/OPAEPackaging.cmake
+++ b/cmake/modules/OPAEPackaging.cmake
@@ -172,7 +172,7 @@ function(opae_python_install)
                 COMMAND ${Python3_EXECUTABLE} -m pip install \
                     --root=\$ENV{DESTDIR} \
                     --prefix=${CMAKE_INSTALL_PREFIX} \
-		    --no-warn-script-location .
+                    .
                 WORKING_DIRECTORY ${OPAE_PYTHON_INSTALL_SOURCE_DIR}
             )
         ${APPEND_CODE}


### PR DESCRIPTION
### Description
On certain older Python3 installations, this option is not supported; and when it is encountered, it causes pip to error out.
Its only use is to suppress a warning message.  Removing it will allow older pip's to do the right thing, and newer pip's will show the warning.

### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
CI