### PR TITLE
Update: add --force, --enable-sriov to opae.io

### DIFF
--- a/binaries/opae.io/opae/io/utils.py
+++ b/binaries/opae.io/opae/io/utils.py
@@ -123,9 +123,23 @@ def chown_pci_sva(pci_addr, uid, gid):
         os.chown(sva_bind_dev, uid, gid)
 
 
-def vfio_init(pci_addr, new_owner='', force=False):
+def enable_sriov(enable):
+    sriov = '/sys/module/vfio_pci/parameters/enable_sriov'
+    if os.path.exists(sriov):
+        LOG.info('Enabling SR-IOV for vfio-pci')
+        try:
+            with open(sriov, 'w') as outf:
+                outf.write('Y' if enable else 'N')
+        except OSError:
+            return False
+        return True
+    return False
+
+
+def vfio_init(pci_addr, new_owner='', force=False, **kwargs):
     vid_did = pci.vid_did_for_address(pci_addr)
     driver = get_bound_driver(pci_addr)
+    init_sriov = kwargs.get('enable_sriov')
 
     msg = '(0x{:04x},0x{:04x}) at {}'.format(
         int(vid_did[0], 16), int(vid_did[1], 16), pci_addr)
@@ -213,6 +227,9 @@ def vfio_init(pci_addr, new_owner='', force=False):
         LOG.info('Changing permissions for {} to rw-rw----'.format(device))
         os.chmod(device, 0o660)
         chown_pci_sva(pci_addr, user, group)
+
+    if init_sriov:
+        enable_sriov(True)
 
 
 def vfio_release(pci_addr):

--- a/binaries/opae.io/pymain.h
+++ b/binaries/opae.io/pymain.h
@@ -93,6 +93,13 @@ class init_action(base_action):
         init.add_argument('-d', '--device', dest='sdevice',
                           metavar='DEVICE', type=pci.pci_address,
                           help='the PCIe address of the FPGA device')
+        init.add_argument('-e', '--enable-sriov', action='store_true',
+                          default=False,
+                          help='enable SR-IOV during initialization')
+        init.add_argument('-f', '--force', action='store_true',
+                          default=False,
+                          help='force the driver to unbind, '
+                               'even if saving the previous driver fails')
         init.add_argument('user_group', nargs='?', default='root:root',
                           help='the user:group for assigning device permissions')
 
@@ -100,7 +107,8 @@ class init_action(base_action):
         if not self.device:
             raise SystemExit('Need device for init.')
 
-        utils.vfio_init(self.device, args.user_group)
+        kw = {'enable_sriov': args.enable_sriov}
+        utils.vfio_init(self.device, args.user_group, force=args.force, **kw)
         raise SystemExit(0)
 
 


### PR DESCRIPTION
### Description
Add --force and --enable-sriov options to the subparser for opae.io init. The --force option enables controlling the force parameter to vfio_init() that was previously hard-coded to False.

The --enable-sriov option, when given, causes opae.io init to write 'Y' to /sys/module/vfio_pci/parameters/enable_sriov.

The default value for both options is False.

### Collateral (docs, reports, design examples, case IDs):



- [x] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
$ cat /sys/module/vfio_pci/parameters/enable_sriov
N
$ sudo opae.io init -e -d 0000:ca:00.0 tswhison:tswhison
$ cat /sys/module/vfio_pci/parameters/enable_sriov
Y