### PR TITLE
Fix: fpgareg: pcie address to lower case always (was missing in FPGAREG)

### DIFF
--- a/python/opae.admin/opae/admin/tools/fpgareg.py
+++ b/python/opae.admin/opae/admin/tools/fpgareg.py
@@ -348,14 +348,16 @@ def main():
 
     print(args)
 
-    if not verify_pcie_address(args.addr.lower()):
+    addr = args.addr.lower()
+
+    if not verify_pcie_address(addr):
         sys.exit(1)
 
-    if not verify_fpga_device(args.addr.lower()):
+    if not verify_fpga_device(addr):
         print("Invalid fpga device")
         sys.exit(1)
 
-    fpgareg = FPGAREG(args.addr)
+    fpgareg = FPGAREG(addr)
 
     """ print pf0/fme registers """
     if args.reg == 'pcie' and not fpgareg.pf0_registers():


### PR DESCRIPTION
### Description
fpgareg does not lower case pci address argument when using it to open resource0, so upper case does not work


### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
On physical card N5014:
fpgareg 0000:3B:00.0
fpgareg 0000:3b:00.0
