### PR TITLE
Fix:CXL Host exerciser calculations and output string

### DIFF
--- a/samples/cxl_host_exerciser/cxl_he_cmd.h
+++ b/samples/cxl_host_exerciser/cxl_he_cmd.h
@@ -77,24 +77,22 @@ public:
     cout << "actual data:" << dsm_status->actual_data << endl;
     cout << "expected data:" << dsm_status->expected_data << endl;
 
+    double latency = 0;
+    double perf_data = 0;
     // print bandwidth
     if (dsm_status->num_ticks > 0) {
-      double perf_data =
-          he_num_xfers_to_bw(dsm_status->num_reads + dsm_status->num_writes,
-                             dsm_status->num_ticks);
-      host_exe_->logger_->info("Bandwidth: {0:0.3f} GB/s", perf_data);
-    }
+        perf_data = he_num_xfers_to_bw(dsm_status->num_reads +
+            dsm_status->num_writes, dsm_status->num_ticks);
 
-    if (cxl_latency == HE_CXL_RD_LATENCY) {
-        if (dsm_status->num_ticks > 0 && dsm_status->num_reads > 0) {
-            double latency = (double)((dsm_status->num_ticks / (double)dsm_status->num_reads)
-                *( 2.5));
-
-            host_exe_->logger_->info("Read Latency : {0:0.2f}  nanoseconds", latency);
+        if (cxl_latency == HE_CXL_RD_LATENCY) {
+            latency = (double)(dsm_status->num_ticks * 2.5);
+            host_exe_->logger_->info("Bandwidth: {0:0.3f} GB/s Total transaction time: {1:0.2f}  nanoseconds",
+                perf_data, latency);
+        } else {
+            host_exe_->logger_->info("Bandwidth: {0:0.3f} GB/s", perf_data);
         }
-        else {
-            host_exe_->logger_->info("Read Latency: N/A");
-        }
+    } else {
+        host_exe_->logger_->info("Read Latency: N/A");
     }
 
     cout << "********* DSM Status CSR end *********" << endl;

--- a/samples/cxl_host_exerciser/cxl_he_cmd.h
+++ b/samples/cxl_host_exerciser/cxl_he_cmd.h
@@ -85,6 +85,7 @@ public:
             dsm_status->num_writes, dsm_status->num_ticks);
 
         if (cxl_latency == HE_CXL_RD_LATENCY) {
+            //To convert clock ticks to nanoseconds,multiply the clock ticks by 2.5
             latency = (double)(dsm_status->num_ticks * 2.5);
             host_exe_->logger_->info("Bandwidth: {0:0.3f} GB/s Total transaction time: {1:0.2f}  nanoseconds",
                 perf_data, latency);


### PR DESCRIPTION
The CXL host exerciser read latency output string has been modified with the "Total transaction time  nanoseconds".

