### PR TITLE
Fix: Remove latency iterations from write cache hit/miss scenario tests

### DIFF
--- a/samples/cxl_host_exerciser/cxl_he_cmd.h
+++ b/samples/cxl_host_exerciser/cxl_he_cmd.h
@@ -327,6 +327,18 @@ public:
       return false;
   }
 
+  uint64_t get_ticks() {
+      volatile he_cache_dsm_status* dsm_status = NULL;
+
+      dsm_status = reinterpret_cast<he_cache_dsm_status*>(
+          (uint8_t*)(host_exe_->get_dsm()));
+      if (!dsm_status)
+          return 0;
+      if (dsm_status->num_ticks > 0)
+          return dsm_status->num_ticks;
+      else
+          return 0;
+  }
 
 protected:
   host_exerciser *host_exe_;

--- a/samples/cxl_host_exerciser/cxl_host_exerciser.h
+++ b/samples/cxl_host_exerciser/cxl_host_exerciser.h
@@ -44,6 +44,7 @@ static const uint64_t BUFFER_SIZE_32KB = 32* KB;
 static const uint64_t FPGA_32KB_CACHE_LINES = (32 * KB) / 64;
 static const uint64_t FPGA_2MB_CACHE_LINES = (2 * MB) / 64;
 static const uint64_t FPGA_512CACHE_LINES = 512;
+static const double LATENCY_FACTOR = 2.5;
 
 // Host execiser CSR Offset
 enum {

--- a/samples/cxl_host_exerciser/he_cache_test.h
+++ b/samples/cxl_host_exerciser/he_cache_test.h
@@ -772,7 +772,7 @@ public:
       goto out_free;
     }
 
-    logger_->debug("nDFL_CXL_CACHE_WR_ADDR_TABLE_DATA     : 0x:{0:x}", *u64_rd);
+    logger_->debug("DFL_CXL_CACHE_WR_ADDR_TABLE_DATA     : 0x:{0:x}", *u64_rd);
     logger_->debug("DFL_CXL_CACHE_WR_ADDR_TABLE_DATA     : 0x:{0:x}", *u64_wr);
 
     rd_wr_buffer_ = (uint8_t *)ptr;
@@ -811,7 +811,7 @@ public:
            << endl;
     }
 
-    logger_->debug("nDFL_CXL_CACHE_WR_ADDR_TABLE_DATA     : 0x:{0:x}", *u64_rd);
+    logger_->debug("DFL_CXL_CACHE_WR_ADDR_TABLE_DATA     : 0x:{0:x}", *u64_rd);
     logger_->debug("DFL_CXL_CACHE_WR_ADDR_TABLE_DATA     : 0x:{0:x}", *u64_wr);
 
     buffer_release(rd_wr_buffer_, rd_wr_buf_len_);


### PR DESCRIPTION
   - CXL host exerciser Remove latency iterations tests from write cache hit/miss scenario
   - Remove Bandwidth calculation and output in Read cache hit/miss scenario

