### PR TITLE
Fix: correct issue pointed out by static analysis

### DIFF
--- a/binaries/opae.io/main.h
+++ b/binaries/opae.io/main.h
@@ -119,6 +119,9 @@ struct vfio_device {
     close();
   }
 
+  vfio_device(const vfio_device &) = delete;
+  vfio_device &operator=(const vfio_device &) = delete;
+
   static vfio_device* open(const char *pci_addr)
   {
     opae_vfio *v = new opae_vfio();


### PR DESCRIPTION
### Description
Static analysis complained that although a destructor had been defined in class vfio_device, there was not a corresponding copy ctor nor assignment operator. The variable is treated as a Singleton in the application, so no copying occurs.  Implementing the constructor and assignment operator as deleted solves the issue.

### Collateral (docs, reports, design examples, case IDs):


- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
CI