### PR TITLE
Fix: correct opae.io build issue

### DIFF
--- a/binaries/opae.io/main.h
+++ b/binaries/opae.io/main.h
@@ -222,6 +222,5 @@ private:
   opae_vfio *v_;
   vfio_device(opae_vfio *v)
     : v_(v){}
-  vfio_device(const vfio_device &);
 };
 


### PR DESCRIPTION
### Description
Removes multiple declaration of copy ctor from class vfio_device.


### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
