### PR TITLE
fix:CXL traffic generator read/write bandwidth and input arguments bou…

### DIFF
--- a/samples/cxl_mem_tg/cxl_mem_tg.h
+++ b/samples/cxl_mem_tg/cxl_mem_tg.h
@@ -36,6 +36,11 @@ namespace cxl_mem_tg {
 using opae::fpga::types::token;
 const char *AFU_ID = "4DADEA34-2C78-48CB-A3DC-5B831F5CECBB";
 
+static const uint64_t CL = 64;
+static const uint64_t KB = 1024;
+static const uint64_t MB = KB * 1024;
+static const uint64_t GB = MB * 1024;
+static const uint64_t FPGA_32GB_CACHE_LINES = (32 * GB) / 64;
 static const uint64_t MEM_TG_TEST_TIMEOUT = 3000000;
 static const uint64_t TEST_SLEEP_INVL = 100;
 static const uint64_t TG_CTRL_CLEAR = 0x8000000000000000;
@@ -82,6 +87,8 @@ enum {
   MEM_TG_CLK_COUNT = 0x0050,
   MEM_TG_WR_COUNT = 0x0058,
   MEM_TG_CLK_FREQ = 0x0060,
+  MEM_SIZE = 0x0068,
+
 };
 const int MEM_TG_CFG_OFFSET = 0x1000;
 
@@ -179,6 +186,16 @@ union mem_tg1_count {
   };
 };
 
+// Memory Size
+union tg_mem_size {
+    enum { offset = MEM_SIZE };
+    uint64_t value;
+    struct {
+        uint64_t total_mem_size : 32;
+        uint64_t hdm_mem_size : 32;
+    };
+};
+
 using test_afu = opae::afu_test::afu;
 using test_command = opae::afu_test::command;
 
@@ -193,7 +210,9 @@ class cxl_mem_tg : public test_afu {
         rcnt_(1),
         bcnt_(1),
         stride_(1),
-        mem_speed_(TG_FREQ) {
+        mem_speed_(TG_FREQ),
+        hdm_size_(FPGA_32GB_CACHE_LINES)
+  {
     // iterations
     app_.add_option("--count", count_, "Number of iterations to run")
         ->default_val("1");
@@ -259,6 +278,7 @@ class cxl_mem_tg : public test_afu {
   uint64_t mem_speed_;
   uint32_t status_;
   uint64_t tg_offset_;
+  uint64_t hdm_size_;
 
   std::map<uint32_t, uint32_t> limits_;
 

--- a/samples/cxl_mem_tg/cxl_tg_test.h
+++ b/samples/cxl_mem_tg/cxl_tg_test.h
@@ -43,6 +43,8 @@ using opae::fpga::types::token;
 
 #define CXL_TG_BW_FACTOR   0.931323
 
+#define MAX(x, y) ((x) > (y) ? (x) : (y))
+
 /*
 1) Write to TG_CLEAR with data=0xF to clear all the failure status registers.
 2) Configure the registers with the value specified in table 1 below.
@@ -96,6 +98,8 @@ class cxl_tg_test : public test_command {
     tg_exe_->logger_->debug("GUIDH:0x{:x}", tg_exe_->read64(AFU_ID_H));
     tg_exe_->logger_->debug("TG Contol:0x{:x}", tg_exe_->read64(MEM_TG_CTRL));
     tg_exe_->logger_->debug("TG Status:0x{:x}", tg_exe_->read64(MEM_TG_STAT));
+    tg_exe_->logger_->debug("Memory Size:0x{:x}",
+                            tg_exe_->read64(MEM_SIZE));
     tg_exe_->logger_->debug("TG Total clock count:0x{:x}",
                             tg_exe_->read64(MEM_TG_CLK_COUNT));
     tg_exe_->logger_->debug("TG Write Clock Count:0x{:x}",
@@ -271,15 +275,48 @@ class cxl_tg_test : public test_command {
   // Configure the registers with the value
   int config_input_options() {
 
-
     mem_tg_ctl tg_ctl;
     tg_ctl.value = tg_exe_->read64(MEM_TG_CTRL);
     tg_exe_->logger_->debug("tg configure input options...");
     tg_exe_->logger_->debug("mem tg ctl:{0:x}", tg_ctl.value);
 
+    tg_mem_size mem_size;
+    mem_size.value = tg_exe_->read64(MEM_SIZE);
+
+    uint64_t value = mem_size.total_mem_size;
+    tg_exe_->logger_->debug("Total hardware memory size:{}", value);
+    value = mem_size.hdm_mem_size;
+    tg_exe_->logger_->debug("HDM memory size:{0:d}", value);
+
+    if (mem_size.hdm_mem_size != 0)
+        tg_exe_->hdm_size_ = mem_size.hdm_mem_size;
+
+   cout << "HDM memory cache line size:" << dec << tg_exe_->hdm_size_ << endl;
+
     if (tg_ctl.tg_capability != 0x1) {
-      std::cerr << "No traffic generator for mem" << std::endl;
+      cerr << "No traffic generator for memory" << endl;
       return -1;
+    }
+
+    if (tg_exe_->wcnt_ == 0 && tg_exe_->rcnt_ == 0) {
+        cerr << "Invalid Read and Write input arguments" << endl;
+        return -1;
+    }
+
+    if (tg_exe_->rcnt_ > tg_exe_->wcnt_) {
+        cerr << "Read cout exceed Write count" << endl;
+        return -1;
+    }
+
+    if ( tg_exe_->wcnt_ == 0) {
+        cerr << " Write count is zero" << endl;
+        return -1;
+    }
+
+    if ( (MAX(tg_exe_->wcnt_, tg_exe_->rcnt_) * tg_exe_->loop_) >=
+        tg_exe_->hdm_size_) {
+        cerr << "Read,Write and loop cout exceed HDM memory size" << endl;
+        return -1;
     }
 
     tg_exe_->mem_speed_ = tg_exe_->read64(MEM_TG_CLK_FREQ);


### PR DESCRIPTION
…ndary check

fix#1
For the correct value of loop count, the following condition must be satisfied. max(READ,WRITE) * loop_count <= 268,435,456

fix #2
cannot have READs only (without any previous WRITEs)

fix #3
 READs cannot exceed #WRITEs

Fix #4
Read HDM size from CSR.
