### PR TITLE
feature: add running pointer and ping-pong  tests to CXL host exerciser

### DIFF
--- a/samples/cxl_host_exerciser/cxl_he_cmd.h
+++ b/samples/cxl_host_exerciser/cxl_he_cmd.h
@@ -34,6 +34,10 @@
 
 #define HE_TEST_STARTED      "Test started ......"
 #define HE_PRTEST_SCENARIO   "Pretest scenario started ......"
+#define HE_PING_PONG   "Ping ong test started ......"
+#define HE_RUNNING_POINTER   "Running pointer test started ......"
+
+#define PFN_MASK_SIZE	8
 
 namespace host_exerciser {
 
@@ -48,6 +52,7 @@ public:
     he_wr_cfg_.value = 0;
     rd_table_ctl_.value = 0;
     wr_table_ctl_.value = 0;
+    he_rd_num_lines_.value = 0;
   }
 
   virtual ~he_cmd() {}
@@ -69,7 +74,7 @@ public:
     cout << "test completed :" << dsm_status->test_completed << endl;
     cout << "dsm number:" << dsm_status->dsm_number << endl;
     cout << "error vector:" << dsm_status->err_vector << endl;
-    cout << "num ticks:" << dsm_status->num_ticks << endl;
+    cout << "num ticks:" << std::dec << dsm_status->num_ticks << endl;
     cout << "num reads:" << dsm_status->num_reads << endl;
     cout << "num writes:" << dsm_status->num_writes << endl;
     cout << "penalty start:" << dsm_status->penalty_start << endl;
@@ -227,11 +232,11 @@ public:
 
   bool he_wait_test_completion() {
     /* Wait for test completion */
-    uint32_t timeout = HELPBK_TEST_TIMEOUT;
+    uint32_t timeout = HE_CACHE_TEST_TIMEOUT;
 
     volatile uint8_t *status_ptr = host_exe_->get_dsm();
     while (0 == ((*status_ptr) & 0x1)) {
-      usleep(HELPBK_TEST_SLEEP_INVL);
+      usleep(HE_CACHE_TEST_SLEEP_INVL);
       if (--timeout == 0) {
         cout << "HE Cache time out error" << endl;
         return false;
@@ -265,14 +270,21 @@ public:
   }
 
 
-  void he_start_test(const char* str = HE_TEST_STARTED) {
+  void he_start_test(const char* str = HE_TEST_STARTED, uint8_t test_type = RD_WR_TEST) {
       // start test
+    he_ctl_.test_type = test_type;
     he_ctl_.Start = 0;
     host_exe_->write64(HE_CTL, he_ctl_.value);
     he_ctl_.Start = 1;
     host_exe_->write64(HE_CTL, he_ctl_.value);
 
+    he_ctl_.Start = 0;
+    host_exe_->write64(HE_CTL, he_ctl_.value);
+
     cout << str << endl;
+
+    host_exe_->logger_->debug("Test type :0x{:x} ", test_type);
+    host_exe_->logger_->debug("HE_CTL:0x{:x}", host_exe_->read64(HE_CTL));
   }
 
   bool verify_numa_node() {
@@ -339,6 +351,226 @@ public:
           return 0;
   }
 
+  int  get_mtime(const char* file_name, struct timespec* mtime)
+  {
+      struct stat s;
+
+      if (!lstat(file_name, &s)) {
+          if (S_ISLNK(s.st_mode)) {
+              mtime->tv_sec = mtime->tv_nsec = 0;
+              return -1;
+          }
+          mtime->tv_sec = s.st_mtime;
+          mtime->tv_nsec = s.st_mtim.tv_nsec;
+          return 0;
+      }
+      else {
+          mtime->tv_sec = mtime->tv_nsec = 0;
+          return errno;
+      }
+  }
+
+  int file_open(const char* file_name, int mode)
+  {
+      struct stat before, after;
+      int fd;
+      int ret;
+
+      ret = lstat(file_name, &before);
+      if (ret == 0) {
+          if (S_ISLNK(before.st_mode))
+              return -1;
+      }
+
+      fd = open(file_name, mode, 0x666);
+      if (fd < 0)
+          return -1;
+
+      if (ret == 0) {
+          if (fstat(fd, &after) == 0) {
+              if (before.st_ino != after.st_ino) {
+                  close(fd);
+                  return -1;
+              }
+          }
+          else {
+              close(fd);
+              return -1;
+          }
+      }
+      return fd;
+  }
+
+   uint64_t __mem_virt2phys(const void* virtaddr)
+  {
+      int page_size = getpagesize();
+      struct timespec mtime1, mtime2;
+      const char* fname = "/proc/self/pagemap";
+      unsigned long pfn;
+      uint64_t page;
+      off_t offset;
+      int fd, retval;
+
+      retval = get_mtime(fname, &mtime1);
+      if (retval) {
+          cerr << "stat failed\n";
+          return -1;
+      }
+
+      fd = file_open("/proc/self/pagemap", O_RDONLY | O_EXCL);
+      if (fd < 0)
+          return -1;
+
+      pfn = (unsigned long)virtaddr / page_size;
+      offset = pfn * sizeof(uint64_t);
+      if (lseek(fd, offset, SEEK_SET) == (off_t)-1) {
+          cerr << "seek error\n";
+          close(fd);
+          return -1;
+      };
+
+      retval = get_mtime(fname, &mtime2);
+      if (retval) {
+          cerr << "stat failed\n";
+          close(fd);
+          return -1;
+      }
+
+      if (mtime1.tv_sec != mtime2.tv_sec
+          || mtime1.tv_nsec != mtime2.tv_nsec) {
+          cerr << "file got modified after open \n";
+          close(fd);
+          return -1;
+      }
+
+      retval = read(fd, &page, PFN_MASK_SIZE);
+      close(fd);
+      if (retval != PFN_MASK_SIZE)
+          return -1;
+      if ((page & 0x7fffffffffffffULL) == 0)
+          return -1;
+
+      return ((page & 0x7fffffffffffffULL) * page_size)
+          + ((unsigned long)virtaddr & (page_size - 1));
+  }
+
+   bool create_linked_list(uint64_t *virt_ptr_a, uint64_t phy_ptr_a,
+       uint64_t data, uint64_t max_size,
+       uint64_t *virt_ptr_b = NULL, uint64_t phy_ptr_b = 0) {
+
+       uint64_t *temp_virt_ptr_a       = virt_ptr_a;
+       uint64_t temp_phy_ptr_a         = phy_ptr_a;
+       uint64_t *temp_virt_ptr_b       = virt_ptr_b;
+       uint64_t temp_phy_ptr_b         = phy_ptr_b;
+       uint64_t i                      = 0;
+       struct he_cache_running_ptr *temp_node = NULL;
+
+       host_exe_->logger_->debug("virt_ptr_a:0x{:x}", fmt::ptr(virt_ptr_a));
+       host_exe_->logger_->debug("phy_ptr_a:0x{:x}", phy_ptr_a);
+       host_exe_->logger_->debug("virt_ptr_b:0x{:x}", fmt::ptr(virt_ptr_b));
+       host_exe_->logger_->debug("phy_ptr_b:0x{:x}", phy_ptr_b);
+       host_exe_->logger_->debug("max_size:{0}", max_size);
+       host_exe_->logger_->debug("data:{:x}", data);
+
+       if (virt_ptr_a == NULL || phy_ptr_a == 0) {
+           cerr << "Invalid input arguments" << endl;
+           return false;
+       }
+
+       // Linked list on host or fpga memory
+       if (virt_ptr_a != NULL && phy_ptr_a != 0 &&
+           virt_ptr_b == NULL && phy_ptr_b == 0) {
+
+           temp_node = (struct he_cache_running_ptr*)(temp_virt_ptr_a);
+
+           for (i = 0; i < max_size; ++i) {
+               temp_node->phy_next_ptr = temp_phy_ptr_a + 64;
+               temp_node->data = data;
+               temp_node->virt_next_ptr = (struct he_cache_running_ptr*)(temp_virt_ptr_a + 8);
+
+               temp_node++;
+               temp_phy_ptr_a = temp_phy_ptr_a + 64;
+               temp_virt_ptr_a = temp_virt_ptr_a + 8;
+           }
+
+           temp_node->phy_next_ptr = 0;
+           temp_node->virt_next_ptr = NULL;
+           temp_node->data = 0;
+       }
+
+  
+       // Linked list on host and fpga memory
+       if (virt_ptr_a != NULL && phy_ptr_a != 0 &&
+           virt_ptr_b != NULL && phy_ptr_b != 0) {
+
+           struct he_cache_running_ptr* temp_node_a = 
+               (struct he_cache_running_ptr*)(temp_virt_ptr_a);
+
+           struct he_cache_running_ptr* temp_node_b =
+               (struct he_cache_running_ptr*)(temp_virt_ptr_b);
+
+           int which = 0;
+           for (i = 0; i <  max_size; ++i) {
+
+               if (which == 0) {
+                   temp_node_a->phy_next_ptr = temp_phy_ptr_b;
+                   temp_node_a->data =  data;
+                   temp_node_a->virt_next_ptr = temp_node_b;
+                   ++temp_node_a;
+                   temp_phy_ptr_a += 64;
+
+               } else {
+                   temp_node_b->phy_next_ptr = temp_phy_ptr_a;
+                   temp_node_b->data = data;
+                   temp_node_b->virt_next_ptr = temp_node_a;
+                   ++temp_node_b;
+                   temp_phy_ptr_b += 64;
+               }
+
+               which = 1 - which;
+           }
+
+           temp_node_a->phy_next_ptr = 0;
+           temp_node_a->virt_next_ptr = nullptr;
+
+           temp_node_b->phy_next_ptr = 0;
+           temp_node_b->virt_next_ptr = nullptr;
+       }
+
+        return true;
+   }
+
+   bool verify_linked_list(uint64_t* virt_ptr, uint64_t phy_ptr,
+       uint64_t data, uint64_t max_size) {
+
+       bool  retval = true;
+       struct he_cache_running_ptr* temp = NULL;
+       uint64_t i = 0;
+
+       host_exe_->logger_->debug("virt_ptr:0x{:x}", fmt::ptr(virt_ptr));
+       host_exe_->logger_->debug("phy_ptr:0x{:x}", phy_ptr);
+       host_exe_->logger_->debug("max_size:{0}", max_size);
+       host_exe_->logger_->debug("data:{:x}", data);
+
+       temp = (struct he_cache_running_ptr*)(virt_ptr);
+
+       for (i = 0; i < max_size; i++) {
+
+               if (temp == NULL) {
+                   retval = false;
+                   break;
+           }
+           // 1's complement of data
+           if (temp->data != ~data) {
+               cerr << "Failed to convert data to 1's complement at index:" << i << endl;
+               retval = false;
+               break;
+           }
+           temp = temp->virt_next_ptr;
+       }
+       return retval;
+   }
+
 protected:
   host_exerciser *host_exe_;
   uint32_t he_clock_mhz_;
@@ -352,5 +584,6 @@ protected:
   he_wr_config he_wr_cfg_;
   he_rd_addr_table_ctrl rd_table_ctl_;
   he_wr_addr_table_ctrl wr_table_ctl_;
+  he_rd_num_lines he_rd_num_lines_;
 };
 } // end of namespace host_exerciser


### PR DESCRIPTION
 -Running pointer test:
   Create linked list in Host or fpga memory, write linked list head pointer to AFU read address table,   AFU test execution walks linked list, updates buffer’s data to 1’s complements

 - Ping pong-pong test: Allocate  Host or fpga memory, write ping pong buffer physical address  to AFU read address table, AFU test execution increment buffer value to odd number , SW updates to event number until maximum count.

