### PR TITLE
fix: set FPGA buffer read only for bias mode device bias.

### DIFF
--- a/libraries/plugins/xfpga/fpga-dfl.h
+++ b/libraries/plugins/xfpga/fpga-dfl.h
@@ -377,6 +377,7 @@ struct dfl_cxl_cache_region_info {
  */
 struct dfl_cxl_cache_buffer_map {
 	__u32 argsz;
+#define DFL_CXL_BUFFER_MAP_WRITABLE 1
 	__u32 flags;
 	__u64 user_addr;
 	__u64 length;

--- a/samples/cxl_host_exerciser/cxl_he_cmd.h
+++ b/samples/cxl_host_exerciser/cxl_he_cmd.h
@@ -263,6 +263,7 @@ public:
             he_ctl_.bias_support = FPGAMEM_HOST_BIAS;
         } else {
             he_ctl_.bias_support = FPGAMEM_DEVICE_BIAS;
+            host_exe_->set_mmap_access(HE_CACHE_DMA_MMAP_R);
         }
     }
 


### PR DESCRIPTION
  - Set Host and FPGA buffer map  Writable for Host BIAS mode targeting Host address and Host BIAS mode targeting HDM  (Device) address
  - Set FPGA buffer map read-only for device BIAS mode targeting HDM (Device) address

   CXL Driver IOCTL  buffer map by default Read-only flag value is 0,
   Set buffer map flag to  DFL_CXL_BUFFER_MAP for Read/write buffers

   struct dfl_cxl_cache_buffer_map {
 	__u32 argsz;
   #define DFL_CXL_BUFFER_MAP_WRITABLE 1
 	__u32 flags;
 	__u64 user_addr;
 	__u64 length;
   }

*PR Title should start with one of the following tags: [Fix]/[Feature]/[Style]/[Update]*

*[Fix]- Bug Fix*

*[Feature]- for new feature*

*[Style]- Grammar or branding fix*

*[Update]-For an update to an existing feature*

------------- *Keep everything below this line* -------------------------

### Description
*Describe the issue, update, change or fix and **why***


### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
