### PR TITLE
FIX: flashupdate.py fix for intel PAC n3000 cards - boot_page

### DIFF
--- a/python/opae.admin/opae/admin/tools/fpgasupdate.py
+++ b/python/opae.admin/opae/admin/tools/fpgasupdate.py
@@ -825,21 +825,23 @@ def main():
     # The bootpage is read from the fpga_boot_image sysfs entry. The 'fme' object has many sysfs_nodes
     # for various items, including the boot_page, so we use that here. It simply returns a string
     # indicating the boot page: fpga_factory, fpga_user1, or fpga_user2
-
-    boot_page = pac.fme.boot_page
-    if boot_page is None:
+ 
+    #boot_page only supported by PMCI interface
+    if pac.fme.spi_bus is None:
+      boot_page = pac.fme.boot_page
+      if boot_page is None:
         LOG.error('Secure update failed. Could not find **/fpga_boot_image sysfs entry.')
         sys.exit(1)        
 
-    LOG.debug ("Boot page sysfs path: %s\n", boot_page.sysfs_path)
-    LOG.debug ("Boot page value: %s\n", boot_page.value)
-    LOG.debug ('Block0 ConType: %s\n', blk0['ConType'])
+      LOG.debug ("Boot page sysfs path: %s\n", boot_page.sysfs_path)
+      LOG.debug ("Boot page value: %s\n", boot_page.value)
+      LOG.debug ('Block0 ConType: %s\n', blk0['ConType'])
 
-    # The binary is produced by the PACSign utility. 
-    # CONTENT_FACTORY is the enum that PACSign inserts into the block0 region of
-    # the binary to indicate that the factory image is targeted. ConType refers to 'content type'
-    # and indicates if the binary is factoryPR, static region, BMC-related etc.
-    if ((boot_page.value == 'fpga_factory') and (blk0['ConType'] == CONTENT_FACTORY)):
+      # The binary is produced by the PACSign utility. 
+      # CONTENT_FACTORY is the enum that PACSign inserts into the block0 region of
+      # the binary to indicate that the factory image is targeted. ConType refers to 'content type'
+      # and indicates if the binary is factoryPR, static region, BMC-related etc.
+      if ((boot_page.value == 'fpga_factory') and (blk0['ConType'] == CONTENT_FACTORY)):
         LOG.error('Secure update failed. Cannot update factory image when current boot-page is also factory.')
         sys.exit(1)
 


### PR DESCRIPTION
Issue:
fpgasupdate.py does not work on intel PAC n3000 devices due to added check for updating FPGA factory image when running factory image.

Found:
The boot_page is only implemented in PMCI driver not the SPI driver.

Changed:
Checked for SPI bus:
Seems that a check for spi_bus is used several places in the fpga.py.  I do not have knowledge - if the Intel PAC n3000 NIOS can supply which fpga image loaded in another way, so just disabled the factory update check for SPI interfaces.

Test: 
Success - programmed user image on Intel PAC n3000.
