### PR TITLE
Fix: define PCI_STD_NUM_BARS when not found

### DIFF
--- a/libraries/plugins/uio/dfl.c
+++ b/libraries/plugins/uio/dfl.c
@@ -31,6 +31,10 @@
 #include <time.h>
 #include <sys/pci.h>
 
+#ifndef PCI_STD_NUM_BARS
+#define PCI_STD_NUM_BARS 6
+#endif // PCI_STD_NUM_BARS
+
 #include "opae_int.h"
 #include "opae_uio.h"
 #include "dfl.h"

--- a/libraries/plugins/vfio/dfl.c
+++ b/libraries/plugins/vfio/dfl.c
@@ -31,6 +31,10 @@
 #include <time.h>
 #include <sys/pci.h>
 
+#ifndef PCI_STD_NUM_BARS
+#define PCI_STD_NUM_BARS 6
+#endif // PCI_STD_NUM_BARS
+
 #include "opae_int.h"
 #include "opae_vfio.h"
 #include "dfl.h"


### PR DESCRIPTION
### Description
A recent checkin began relying on sys/pci.h for its definition of PCI_STD_NUM_BARS.
It seems that some distributions don't have a version of that file that defines PCI_STD_NUM_BARS.
This change defines it to 6 when not found.

### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
CI