### PR TITLE
fix: CXL host exerciser  segmentation fault non-root user mode

### DIFF
--- a/samples/cxl_host_exerciser/cxl_he_cache_cmd.h
+++ b/samples/cxl_host_exerciser/cxl_he_cache_cmd.h
@@ -1096,7 +1096,7 @@ public:
       host_exe_->write64(HE_RD_ADDR_TABLE_DATA, phy_ptr);
 
       // start test
-      he_start_test(HE_PING_PONG,RUNNING_POINTER);
+      he_start_test(HE_RUNNING_POINTER,RUNNING_POINTER);
 
       // wait for completion
       if (!he_wait_test_completion()) {

--- a/samples/cxl_host_exerciser/he_cache_test.h
+++ b/samples/cxl_host_exerciser/he_cache_test.h
@@ -435,7 +435,7 @@ public:
     logger_->debug("DFH + 16: 0x:{0:X}", *(u64 + 2));
     logger_->debug("DFH + 24: 0x:{0:X}", *(u64 + 3));
 
-    return exit_codes::not_run;
+    return exit_codes::success;
   }
 
   int main(int argc, char *argv[]) {
@@ -474,7 +474,8 @@ public:
     }
 
     int res = open_handle(dev_path_[dev_index].c_str());
-    if (res != exit_codes::not_run) {
+    if (res != exit_codes::success) {
+      cerr << "Failed to open cxl device" << endl;
       return res;
     }
 


### PR DESCRIPTION
 -CXL host exerciser  segmentation fault occurs in non-root user mode,
  exit application if clx device open fails.
 - CXL host exerciser  running pointer tests show wrong "data ping pong tests", Change to "Running pointer test started ......"
