### PR TITLE
fix: (Cherry-pick) CXL host exerciser running pointer test output wrong  string (#3…

### DIFF
--- a/samples/cxl_host_exerciser/cxl_he_cache_cmd.h
+++ b/samples/cxl_host_exerciser/cxl_he_cache_cmd.h
@@ -1096,7 +1096,7 @@ public:
       host_exe_->write64(HE_RD_ADDR_TABLE_DATA, phy_ptr);
 
       // start test
-      he_start_test(HE_PING_PONG,RUNNING_POINTER);
+      he_start_test(HE_RUNNING_POINTER,RUNNING_POINTER);
 
       // wait for completion
       if (!he_wait_test_completion()) {


### PR DESCRIPTION
…068)

-CXL host exerciser running pointer tests show wrong "data ping pong tests".
   Change to "Running pointer test started ......"
