### PR TITLE
[Feature] - Add parent/child AFU management to the libopae-c shell

### DIFF
--- a/include/opae/access.h
+++ b/include/opae/access.h
@@ -73,6 +73,36 @@ fpga_result fpgaOpen(fpga_token token, fpga_handle *handle,
 		     int flags);
 
 /**
+ * Extract the handles of children of a previously fpgaOpen()ed resource.
+ * Only AFUs with feature parameters that name child AFU GUIDs will have
+ * children.
+ *
+ * Child AFU handles may be used to connect to child-specific MMIO regions
+ * and manage interrupts. Children will be closed automatically along with
+ * the parent. fpgaClose() should not be called on returned child handles.
+ *
+ * Child handles may not be passed to fpgaPrepareBuffer(). All shared
+ * memory management must be associated with the parent.
+ *
+ * @param[in]  handle       Handle to previously opened FPGA object
+ * @param[in]  max_children Maximum number of handles that may be returned
+ *                          in the `children` array.
+ * @param[out] children     Pointer to an array of child handles currently
+ *                          open. When NULL or `max_children` is 0, the
+ *                          number of children will still be returned in
+ *                          `num_children`.
+ * @param[out] num_children Number of children belonging to the parent.
+ *                          This number may be higher than `max_children`.
+ * @returns                 FPGA_OK on success.
+ *                          FPGA_INVALID_PARAM if handle does not refer to
+ *                          an acquired resource, or if handle is NULL.
+ *                          FPGA_EXCEPTION if an internal error occurred
+ *                          while accessing the handle.
+ */
+fpga_result fpgaGetChildren(fpga_handle handle, uint32_t max_children,
+			    fpga_handle *children, uint32_t *num_children);
+
+/**
  * Close a previously opened FPGA object
  *
  * Relinquishes ownership of a previously fpgaOpen()ed resource. This enables

--- a/libraries/libopae-c/CMakeLists.txt
+++ b/libraries/libopae-c/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SRC
     api-shell.c
     init.c
     props.c
+    multi-port-afu.c
     cfg-file.c
     fpgad-cfg.c
     fpgainfo-cfg.c

--- a/libraries/libopae-c/adapter.h
+++ b/libraries/libopae-c/adapter.h
@@ -102,7 +102,21 @@ typedef struct _opae_api_adapter_table {
 
 	fpga_result (*fpgaGetIOAddress)(fpga_handle handle, uint64_t wsid,
 					uint64_t *ioaddr);
+
 	fpga_result (*fpgaBindSVA)(fpga_handle handle, uint32_t *pasid);
+
+	// Internal methods between shell and plugin to pin/unpin an existing
+	// buffer at a specific ioaddr. Used when managing the same address
+	// space on parent and child AFU ports, all opened by the same process.
+	fpga_result (*fpgaPinBuffer)(fpga_handle handle, void *buf_addr,
+				     uint64_t len, uint64_t ioaddr);
+	fpga_result (*fpgaUnpinBuffer)(fpga_handle handle, void *buf_addr,
+				       uint64_t len, uint64_t ioaddr);
+
+	// Internal method to extract details of a workspace.
+	fpga_result (*fpgaGetWSInfo)(fpga_handle handle, uint64_t wsid,
+				     uint64_t *ioaddr,
+				     void **buf_addr, uint64_t *len);
 
 	/*
 	**	fpga_result (*fpgaGetOPAECVersion)(fpga_version *version);

--- a/libraries/libopae-c/api-shell.c
+++ b/libraries/libopae-c/api-shell.c
@@ -40,6 +40,7 @@
 #include "pluginmgr.h"
 #include "opae_int.h"
 #include "props.h"
+#include "multi-port-afu.h"
 #include "mock/opae_std.h"
 
 const char *
@@ -195,6 +196,8 @@ opae_allocate_wrapped_handle(opae_wrapped_token *wt, fpga_handle opae_handle,
 		whan->wrapped_token = wt;
 		whan->opae_handle = opae_handle;
 		whan->adapter_table = adapter;
+		whan->parent = NULL;
+		whan->child_next = NULL;
 
 		opae_upref_wrapped_token(wt);
 	}
@@ -276,6 +279,7 @@ fpga_result __OPAE_API__ fpgaOpen(fpga_token token, fpga_handle *handle,
 	fpga_result res;
 	fpga_result cres = FPGA_OK;
 	opae_wrapped_token *wrapped_token;
+	fpga_token_header *token_hdr;
 	fpga_handle opae_handle = NULL;
 	opae_wrapped_handle *wrapped_handle;
 
@@ -302,9 +306,61 @@ fpga_result __OPAE_API__ fpgaOpen(fpga_token token, fpga_handle *handle,
 		cres = wrapped_token->adapter_table->fpgaClose(opae_handle);
 	}
 
+	token_hdr = (fpga_token_header *)wrapped_token->opae_token;
+	if (token_hdr->objtype == FPGA_ACCELERATOR) {
+		res = afu_open_children(wrapped_handle);
+		if (res != FPGA_OK) {
+			// Close any children that are open
+			afu_close_children(wrapped_handle);
+
+			// Close parent due to failure with child
+			if (wrapped_handle->adapter_table->fpgaClose)
+				wrapped_handle->adapter_table->fpgaClose(
+					wrapped_handle->opae_handle);
+
+			opae_destroy_wrapped_handle(wrapped_handle);
+			return res;
+		}
+	}
+
 	*handle = wrapped_handle;
 
 	return res != FPGA_OK ? res : cres;
+}
+
+fpga_result __OPAE_API__ fpgaGetChildren(fpga_handle handle,
+					 uint32_t max_children,
+					 fpga_handle *children,
+					 uint32_t *num_children)
+{
+	opae_wrapped_handle *wrapped_handle =
+		opae_validate_wrapped_handle(handle);
+
+	ASSERT_NOT_NULL(wrapped_handle);
+	ASSERT_NOT_NULL(num_children);
+
+	if ((max_children > 0) && !children) {
+		OPAE_ERR("max_children > 0 with NULL children");
+		return FPGA_INVALID_PARAM;
+	}
+
+	*num_children = 0;
+
+	// Is handle a child? If so, it has no children.
+	if (wrapped_handle->parent)
+		return FPGA_OK;
+
+	// Children are already open
+	opae_wrapped_handle *wrapped_child = wrapped_handle->child_next;
+	while (wrapped_child) {
+		if (*num_children < max_children)
+			children[*num_children] = wrapped_child;
+
+		*num_children += 1;
+		wrapped_child = wrapped_child->child_next;
+	}
+
+	return FPGA_OK;
 }
 
 fpga_result __OPAE_API__ fpgaClose(fpga_handle handle)
@@ -320,6 +376,7 @@ fpga_result __OPAE_API__ fpgaClose(fpga_handle handle)
 	res = wrapped_handle->adapter_table->fpgaClose(
 		wrapped_handle->opae_handle);
 
+	afu_close_children(wrapped_handle);
 	opae_destroy_wrapped_handle(wrapped_handle);
 
 	return res;
@@ -905,6 +962,7 @@ fpga_result __OPAE_API__ fpgaGetUmsgPtr(fpga_handle handle, uint64_t **umsg_ptr)
 fpga_result __OPAE_API__ fpgaPrepareBuffer(fpga_handle handle,
 	uint64_t len, void **buf_addr, uint64_t *wsid, int flags)
 {
+	fpga_result res;
 	opae_wrapped_handle *wrapped_handle =
 		opae_validate_wrapped_handle(handle);
 
@@ -921,12 +979,33 @@ fpga_result __OPAE_API__ fpgaPrepareBuffer(fpga_handle handle,
 	ASSERT_NOT_NULL_RESULT(wrapped_handle->adapter_table->fpgaPrepareBuffer,
 			       FPGA_NOT_SUPPORTED);
 
-	return wrapped_handle->adapter_table->fpgaPrepareBuffer(
+	if (wrapped_handle->parent) {
+		OPAE_ERR("Call fpgaPrepareBuffer() from the parent handle");
+		return FPGA_NOT_SUPPORTED;
+	}
+
+	res = wrapped_handle->adapter_table->fpgaPrepareBuffer(
 		wrapped_handle->opae_handle, len, buf_addr, wsid, flags);
+	if (res != FPGA_OK)
+		return res;
+
+	res = afu_pin_buffer(wrapped_handle, *buf_addr, len, *wsid);
+	if (res == FPGA_OK)
+		return FPGA_OK;
+
+	// Error! Undo pinning of parent after child failure.
+	if (wrapped_handle->adapter_table->fpgaReleaseBuffer)
+		wrapped_handle->adapter_table->fpgaReleaseBuffer(
+			wrapped_handle->opae_handle, *wsid);
+
+	// Return the error
+	return res;
 }
 
 fpga_result __OPAE_API__ fpgaReleaseBuffer(fpga_handle handle, uint64_t wsid)
 {
+	fpga_result ret_res;
+	fpga_result res;
 	opae_wrapped_handle *wrapped_handle =
 		opae_validate_wrapped_handle(handle);
 
@@ -934,8 +1013,13 @@ fpga_result __OPAE_API__ fpgaReleaseBuffer(fpga_handle handle, uint64_t wsid)
 	ASSERT_NOT_NULL_RESULT(wrapped_handle->adapter_table->fpgaReleaseBuffer,
 			       FPGA_NOT_SUPPORTED);
 
-	return wrapped_handle->adapter_table->fpgaReleaseBuffer(
+	ret_res = afu_unpin_buffer(wrapped_handle, wsid);
+
+	res = wrapped_handle->adapter_table->fpgaReleaseBuffer(
 		wrapped_handle->opae_handle, wsid);
+	ret_res = (ret_res == FPGA_OK ? res : ret_res);
+
+	return ret_res;
 }
 
 fpga_result __OPAE_API__ fpgaGetIOAddress(fpga_handle handle, uint64_t wsid,
@@ -955,6 +1039,7 @@ fpga_result __OPAE_API__ fpgaGetIOAddress(fpga_handle handle, uint64_t wsid,
 
 fpga_result __OPAE_API__ fpgaBindSVA(fpga_handle handle, uint32_t *pasid)
 {
+	fpga_result res;
 	opae_wrapped_handle *wrapped_handle =
 		opae_validate_wrapped_handle(handle);
 
@@ -963,8 +1048,25 @@ fpga_result __OPAE_API__ fpgaBindSVA(fpga_handle handle, uint32_t *pasid)
 	if (!wrapped_handle->adapter_table->fpgaBindSVA)
 		return FPGA_NOT_SUPPORTED;
 
-	return wrapped_handle->adapter_table->fpgaBindSVA(
+	res = wrapped_handle->adapter_table->fpgaBindSVA(
 		wrapped_handle->opae_handle, pasid);
+	if (res != FPGA_OK)
+		return res;
+
+	opae_wrapped_handle *wrapped_child = wrapped_handle->child_next;
+	while (wrapped_child) {
+		if (!wrapped_child->adapter_table->fpgaBindSVA)
+			return FPGA_NOT_SUPPORTED;
+
+		res = wrapped_child->adapter_table->fpgaBindSVA(
+			wrapped_child->opae_handle, pasid);
+		if (res != FPGA_OK)
+			return res;
+
+		wrapped_child = wrapped_child->child_next;
+	}
+
+	return FPGA_OK;
 }
 
 fpga_result __OPAE_API__ fpgaGetOPAECVersion(fpga_version *version)

--- a/libraries/libopae-c/api-shell.c
+++ b/libraries/libopae-c/api-shell.c
@@ -277,7 +277,6 @@ fpga_result __OPAE_API__ fpgaOpen(fpga_token token, fpga_handle *handle,
 				  int flags)
 {
 	fpga_result res;
-	fpga_result cres = FPGA_OK;
 	opae_wrapped_token *wrapped_token;
 	fpga_token_header *token_hdr;
 	fpga_handle opae_handle = NULL;
@@ -302,8 +301,8 @@ fpga_result __OPAE_API__ fpgaOpen(fpga_token token, fpga_handle *handle,
 
 	if (!wrapped_handle) {
 		OPAE_ERR("malloc failed");
-		res = FPGA_NO_MEMORY;
-		cres = wrapped_token->adapter_table->fpgaClose(opae_handle);
+		wrapped_token->adapter_table->fpgaClose(opae_handle);
+		return FPGA_NO_MEMORY;
 	}
 
 	token_hdr = (fpga_token_header *)wrapped_token->opae_token;
@@ -325,7 +324,7 @@ fpga_result __OPAE_API__ fpgaOpen(fpga_token token, fpga_handle *handle,
 
 	*handle = wrapped_handle;
 
-	return res != FPGA_OK ? res : cres;
+	return FPGA_OK;
 }
 
 fpga_result __OPAE_API__ fpgaGetChildren(fpga_handle handle,

--- a/libraries/libopae-c/multi-port-afu.c
+++ b/libraries/libopae-c/multi-port-afu.c
@@ -82,6 +82,9 @@ fpga_result afu_open_children(opae_wrapped_handle *wrapped_parent_handle)
 	// Does this AFU have children? Return FPGA_OK if it does not.
 	//
 
+	if (!adapter->fpgaReadMMIO64)
+		return FPGA_OK;
+
 	// DFH must be a v1 AFU with ID 0
 	result = adapter->fpgaReadMMIO64(handle, 0, 0, &v);
 	if (result != FPGA_OK)

--- a/libraries/libopae-c/multi-port-afu.c
+++ b/libraries/libopae-c/multi-port-afu.c
@@ -84,6 +84,11 @@ fpga_result afu_open_children(opae_wrapped_handle *wrapped_parent_handle)
 
 	if (!adapter->fpgaReadMMIO64)
 		return FPGA_OK;
+	// Don't load children if the attached plugin is missing support
+	// for probing workspace IDs for buffer info. Without it, IOVAs
+	// can't be shared with children.
+	if (!adapter->fpgaGetWSInfo)
+		return FPGA_OK;
 
 	// DFH must be a v1 AFU with ID 0
 	result = adapter->fpgaReadMMIO64(handle, 0, 0, &v);

--- a/libraries/libopae-c/multi-port-afu.c
+++ b/libraries/libopae-c/multi-port-afu.c
@@ -1,0 +1,296 @@
+// Copyright(c) 2024, Intel Corporation
+//
+// Redistribution  and	use  in source	and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of	 source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote	 products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT	 SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR	ANY  DIRECT,  INDIRECT,	 INCIDENTAL,  SPECIAL,	EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,	BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,	DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,	 OR TORT  (INCLUDING NEGLIGENCE	 OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,	EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+//
+// Multi-ported AFUs have a parent AFU that names child AFUs by GUID. These
+// functions apply operations to all childen of a parent AFU.
+//
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif // HAVE_CONFIG_H
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif // _GNU_SOURCE
+
+#include <uuid/uuid.h>
+
+#include <opae/properties.h>
+#include <opae/types_enum.h>
+#include <opae/access.h>
+#include <opae/enum.h>
+#include <opae/mmio.h>
+
+#include "pluginmgr.h"
+#include "opae_int.h"
+#include "props.h"
+#include "mock/opae_std.h"
+
+STATIC void api_guid_to_fpga(uint64_t guidh, uint64_t guidl, fpga_guid guid)
+{
+	uint32_t i;
+	uint32_t s;
+
+	// The API expects the MSB of the GUID at [0] and the LSB at [15].
+	s = 64;
+	for (i = 0; i < 8; ++i) {
+		s -= 8;
+		guid[i] = (uint8_t) ((guidh >> s) & 0xff);
+	}
+
+	s = 64;
+	for (i = 0; i < 8; ++i) {
+		s -= 8;
+		guid[8 + i] = (uint8_t) ((guidl >> s) & 0xff);
+	}
+}
+
+fpga_result afu_open_children(opae_wrapped_handle *wrapped_parent_handle)
+{
+	fpga_result result;
+	uint64_t v;
+
+	const opae_api_adapter_table *adapter =
+		wrapped_parent_handle->wrapped_token->adapter_table;
+	fpga_handle handle = wrapped_parent_handle->opae_handle;
+
+	//
+	// Does this AFU have children? Return FPGA_OK if it does not.
+	//
+
+	// DFH must be a v1 AFU with ID 0
+	result = adapter->fpgaReadMMIO64(handle, 0, 0, &v);
+	if (result != FPGA_OK)
+		return result;
+
+	// An AFU?
+	if ((v >> 60) != 1)
+	       return FPGA_OK;
+	// At least v1?
+	if (!((v >> 52) & 0xff))
+	       return FPGA_OK;
+	// ID is 0 (normal AFU)?
+	if (v & 0xfff)
+	       return FPGA_OK;
+
+	// Is there a parameter list?
+	result = adapter->fpgaReadMMIO64(handle, 0, 0x20, &v);
+	if (result != FPGA_OK)
+		return result;
+	if (((v >> 31) & 1) == 0)
+		return FPGA_OK;
+
+	// Look for a parameter with ID 2 (list of child GUIDs)
+	bool found_children = false;
+	uint64_t offset = 0x28;
+	do {
+		result = adapter->fpgaReadMMIO64(handle, 0, offset, &v);
+		if (result != FPGA_OK)
+			return result;
+
+		if ((v & 0xffff) == 2) {
+			found_children = true;
+			offset += 8;
+			break;
+		}
+
+		// Next parameter
+		offset += (v >> 35) * 8;
+	} while (((v >> 32) & 1) == 0); // Continue until EOP
+
+	if (!found_children)
+		return FPGA_OK;
+
+	// Number of children, inferred from the size of the parameter block
+	uint32_t num_children = v >> 36;
+	opae_wrapped_handle *child_prev = NULL;
+
+	// Walk the list of child AFU GUIDs and load them. The resulting
+	// list of child FPGA handles matches the order of the parameter
+	// block.
+	//
+	// *** For most errors, no cleanup is required. Once a child is
+	// *** on the parent's list it will be cleaned up along with
+	// *** the parent.
+	for (uint32_t c = 0; c < num_children; ++c) {
+		fpga_guid guid;
+		uint64_t guidh, guidl;
+
+		result = adapter->fpgaReadMMIO64(handle, 0, offset, &guidl);
+		if (result != FPGA_OK)
+			return result;
+		result = adapter->fpgaReadMMIO64(handle, 0, offset+8, &guidh);
+		if (result != FPGA_OK)
+			return result;
+
+		// Call the shell's public API methods, not the adapter
+		// instance. Children will have their own wrapped handles.
+
+		fpga_properties filter = NULL;
+		result = fpgaGetProperties(NULL, &filter);
+		if (result != FPGA_OK)
+			return result;
+		fpgaPropertiesSetObjectType(filter, FPGA_ACCELERATOR);
+		api_guid_to_fpga(guidh, guidl, guid);
+		fpgaPropertiesSetGUID(filter, guid);
+
+		fpga_token accel_token;
+		uint32_t num_matches;
+		result = fpgaEnumerate(&filter, 1, &accel_token, 1, &num_matches);
+		fpgaDestroyProperties(&filter);
+		if (result != FPGA_OK)
+			return result;
+		if (num_matches == 0) {
+			char guid_str[64];
+			uuid_unparse(guid, guid_str);
+			OPAE_ERR("Child %s not found", guid_str);
+			return FPGA_NOT_FOUND;
+		}
+
+		fpga_handle child_handle;
+		result = fpgaOpen(accel_token, &child_handle, 0);
+		fpgaDestroyToken(&accel_token);
+		if (result != FPGA_OK)
+			return result;
+
+		opae_wrapped_handle *wrapped_child_handle =
+			opae_validate_wrapped_handle(child_handle);
+		ASSERT_NOT_NULL(wrapped_child_handle);
+
+		wrapped_child_handle->parent = wrapped_parent_handle;
+		if (!child_prev)
+			wrapped_parent_handle->child_next = wrapped_child_handle;
+		else
+			child_prev->child_next = wrapped_child_handle;
+		child_prev = wrapped_child_handle;
+
+		// Next child GUID in the parameter block
+		offset += 16;
+	}
+
+	return result;
+}
+
+fpga_result afu_close_children(opae_wrapped_handle *wrapped_parent_handle)
+{
+	opae_wrapped_handle *wrapped_child_next;
+
+	ASSERT_NOT_NULL(wrapped_parent_handle);
+
+	// Is handle actually a child? Avoid recursion.
+	if (wrapped_parent_handle->parent)
+		return FPGA_OK;
+
+	wrapped_child_next = wrapped_parent_handle->child_next;
+	while (wrapped_child_next) {
+		opae_wrapped_handle *wrapped_child = wrapped_child_next;
+		wrapped_child_next = wrapped_child->child_next;
+
+		// Use the public API, which will clean up the wrapper.
+		fpgaClose(wrapped_child);
+	}
+
+	return FPGA_OK;
+}
+
+fpga_result afu_pin_buffer(opae_wrapped_handle *wrapped_parent_handle,
+			   void *buf_addr, uint64_t len, uint64_t wsid)
+{
+	fpga_result res;
+	opae_wrapped_handle *wrapped_child = wrapped_parent_handle->child_next;
+	opae_wrapped_handle *wrapped_undo;
+
+	if (!wrapped_child)
+		return FPGA_OK;
+
+	ASSERT_NOT_NULL_RESULT(wrapped_parent_handle->adapter_table->fpgaGetIOAddress,
+			       FPGA_NOT_SUPPORTED);
+
+	uint64_t ioaddr;
+	res = wrapped_parent_handle->adapter_table->fpgaGetIOAddress(
+		wrapped_parent_handle->opae_handle, wsid, &ioaddr);
+	if (res != FPGA_OK)
+		return res;
+
+	while (wrapped_child) {
+		ASSERT_NOT_NULL_RESULT(wrapped_child->adapter_table->fpgaPinBuffer,
+				       FPGA_NOT_SUPPORTED);
+		res = wrapped_child->adapter_table->fpgaPinBuffer(
+			wrapped_child->opae_handle, buf_addr, len, ioaddr);
+		if (res != FPGA_OK)
+			goto error_child;
+		wrapped_child = wrapped_child->child_next;
+	}
+
+	return FPGA_OK;
+
+error_child:
+	// Undo pinning of any children completed before the error
+	wrapped_undo = wrapped_parent_handle->child_next;
+	while (wrapped_undo != wrapped_child) {
+		if (wrapped_undo->adapter_table->fpgaUnpinBuffer)
+			wrapped_undo->adapter_table->fpgaUnpinBuffer(
+				wrapped_undo->opae_handle, buf_addr, len, ioaddr);
+
+		wrapped_undo = wrapped_undo->child_next;
+	}
+
+	return res;
+}
+
+fpga_result afu_unpin_buffer(opae_wrapped_handle *wrapped_parent_handle,
+			     uint64_t wsid)
+{
+	fpga_result res;
+	opae_wrapped_handle *wrapped_child = wrapped_parent_handle->child_next;
+	void *buf_addr;
+	uint64_t ioaddr;
+	uint64_t len;
+
+	if (!wrapped_child)
+		return FPGA_OK;
+
+	ASSERT_NOT_NULL_RESULT(wrapped_parent_handle->adapter_table->fpgaGetWSInfo,
+			       FPGA_NOT_SUPPORTED);
+	res = wrapped_parent_handle->adapter_table->fpgaGetWSInfo(
+		wrapped_parent_handle->opae_handle, wsid, &ioaddr, &buf_addr, &len);
+	if (res != FPGA_OK)
+	    return res;
+
+	while (wrapped_child) {
+		ASSERT_NOT_NULL_RESULT(wrapped_child->adapter_table->fpgaUnpinBuffer,
+				       FPGA_NOT_SUPPORTED);
+		res = wrapped_child->adapter_table->fpgaUnpinBuffer(
+			wrapped_child->opae_handle, buf_addr, len, ioaddr);
+		if (res != FPGA_OK)
+			return res;
+
+		wrapped_child = wrapped_child->child_next;
+	}
+
+	return FPGA_OK;
+}

--- a/libraries/libopae-c/multi-port-afu.h
+++ b/libraries/libopae-c/multi-port-afu.h
@@ -1,0 +1,45 @@
+// Copyright(c) 2024, Intel Corporation
+//
+// Redistribution  and  use  in source  and  binary  forms,  with  or  without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of  source code  must retain the  above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * Neither the name  of Intel Corporation  nor the names of its contributors
+//   may be used to  endorse or promote  products derived  from this  software
+//   without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,  BUT NOT LIMITED TO,  THE
+// IMPLIED WARRANTIES OF  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT  SHALL THE COPYRIGHT OWNER  OR CONTRIBUTORS BE
+// LIABLE  FOR  ANY  DIRECT,  INDIRECT,  INCIDENTAL,  SPECIAL,  EXEMPLARY,  OR
+// CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT LIMITED  TO,  PROCUREMENT  OF
+// SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE,  DATA, OR PROFITS;  OR BUSINESS
+// INTERRUPTION)  HOWEVER CAUSED  AND ON ANY THEORY  OF LIABILITY,  WHETHER IN
+// CONTRACT,  STRICT LIABILITY,  OR TORT  (INCLUDING NEGLIGENCE  OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,  EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+//
+// Multi-ported AFUs have a parent AFU that names child AFUs by GUID. These
+// functions apply operations to all childen of a parent AFU.
+//
+
+#ifndef __OPAE_MULTI_PORT_AFU_H__
+#define __OPAE_MULTI_PORT_AFU_H__
+
+#include <stdint.h>
+#include <opae/types.h>
+
+fpga_result afu_open_children(opae_wrapped_handle *wrapped_parent_handle);
+fpga_result afu_close_children(opae_wrapped_handle *wrapped_parent_handle);
+fpga_result afu_pin_buffer(opae_wrapped_handle *wrapped_parent_handle,
+			   void *buf_addr, uint64_t len, uint64_t wsid);
+fpga_result afu_unpin_buffer(opae_wrapped_handle *wrapped_parent_handle,
+			     uint64_t wsid);
+
+#endif // __OPAE_MULTI_PORT_AFU_H__

--- a/libraries/libopae-c/opae_int.h
+++ b/libraries/libopae-c/opae_int.h
@@ -147,6 +147,13 @@ typedef struct _opae_wrapped_handle {
 	opae_wrapped_token *wrapped_token;
 	fpga_handle opae_handle;
 	opae_api_adapter_table *adapter_table;
+
+	// For a multi-ported AFU with declared parent/child, pointer from
+	// child handle to parent.
+	struct _opae_wrapped_handle *parent;
+	// Linked list of children, starting at the parent. The list order
+	// matches the order of the parent's child AFU GUID parameter.
+	struct _opae_wrapped_handle *child_next;
 } opae_wrapped_handle;
 
 opae_wrapped_handle *


### PR DESCRIPTION
### Description
Multi-ported AFUs have a parent AFU that names child AFUs by GUID, encoded in the first entry of a v1 AFU feature list.

- Detect AFUs with children in fpgaOpen() and open all children, associating all open ports with the returned handle.
- When a buffer is pinned in the parent, also pin the buffer at the same IOVA in all children.
- Add fpgaGetChildren() in order to expose child handles for MMIO and interrupts.

### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
host_exerciser on HW, ASE tests