### PR TITLE
[Fix] Only clear AER errors when AER is available

### DIFF
--- a/python/opae.admin/opae/admin/fpga.py
+++ b/python/opae.admin/opae/admin/fpga.py
@@ -666,11 +666,17 @@ class fpga_base(sysfs_device):
         call_process(f'{cmd}={output:08x}')
 
     def clear_uncorrectable_errors(self, device):
+        if not device.supports_ecap('aer'):
+            self.log.debug(f'No AER support in device {device.pci_address}')
+            return
         self.log.debug(f'Clearing uncorrectable errors for {device.pci_address}')
         cmd = f'setpci -s {device.pci_address} ECAP_AER+0x04.L'
         call_process(f'{cmd}=FFFFFFFF')
 
     def clear_correctable_errors(self, device):
+        if not device.supports_ecap('aer'):
+            self.log.debug(f'No AER support in device {device.pci_address}')
+            return
         self.log.debug(f'Clearing correctable errors for {device.pci_address}')
         cmd = f'setpci -s {device.pci_address} ECAP_AER+0x10.L'
         call_process(f'{cmd}=FFFFFFFF')


### PR DESCRIPTION
When using the rsu --force option on systems without AER support the clearing of correctable/uncorrectable errors fails and setpci command returns exit code 1. Fix this by checking the root port for AER support before clearing errors.

------------- *Keep everything below this line* -------------------------

### Description
*Describe the issue, update, change or fix and **why***


### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
