### PR TITLE
[Fix] SEGV when passing NULL buf_addr to fpgaPrepareBuffer()

### DIFF
--- a/libraries/libopae-c/api-shell.c
+++ b/libraries/libopae-c/api-shell.c
@@ -985,7 +985,7 @@ fpga_result __OPAE_API__ fpgaPrepareBuffer(fpga_handle handle,
 
 	res = wrapped_handle->adapter_table->fpgaPrepareBuffer(
 		wrapped_handle->opae_handle, len, buf_addr, wsid, flags);
-	if (res != FPGA_OK)
+	if ((res != FPGA_OK) || !buf_addr)
 		return res;
 
 	res = afu_pin_buffer(wrapped_handle, *buf_addr, len, *wsid);


### PR DESCRIPTION
### Description
Mistaken pointer dereference. buf_addr is allowed to be NULL when testing the fpgaPrepareBuffer() capabilities.

Resolves a regression introduced in commit 4d757b6d.

### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
