### PR TITLE
Feature: add --force, --enable-sriov to opae.io

### DIFF
--- a/binaries/opae.io/pymain.h
+++ b/binaries/opae.io/pymain.h
@@ -93,6 +93,13 @@ class init_action(base_action):
         init.add_argument('-d', '--device', dest='sdevice',
                           metavar='DEVICE', type=pci.pci_address,
                           help='the PCIe address of the FPGA device')
+        init.add_argument('-e', '--enable-sriov', action='store_true',
+                          default=False,
+                          help='enable SR-IOV during initialization')
+        init.add_argument('-f', '--force', action='store_true',
+                          default=False,
+                          help='force the driver to unbind, '
+                               'even if saving the previous driver fails')
         init.add_argument('user_group', nargs='?', default='root:root',
                           help='the user:group for assigning device permissions')
 
@@ -100,7 +107,8 @@ class init_action(base_action):
         if not self.device:
             raise SystemExit('Need device for init.')
 
-        utils.vfio_init(self.device, args.user_group)
+        kw = {'enable_sriov': args.enable_sriov}
+        utils.vfio_init(self.device, args.user_group, force=args.force, **kw)
         raise SystemExit(0)
 
 

--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -3,10 +3,10 @@ Jinja2==3.1.1
 requests==2.31.0
 docutils==0.14
 pygments==2.15.0
-sphinx==4.5.0
+sphinx==5.0.1
 sphinx-rtd-theme==1.0.0
 sphinx_fontawesome==0.0.6
 sphinx-markdown==1.0.2
 recommonmark==0.7.0
-breathe==4.33.1
+breathe==4.34.0
 urllib3==1.26.18

--- a/include/opae/cxx/core/shared_buffer.h
+++ b/include/opae/cxx/core/shared_buffer.h
@@ -62,6 +62,7 @@ class shared_buffer {
   /** shared_buffer factory method - allocate a shared_buffer.
    * @param[in] handle The handle used to allocate the buffer.
    * @param[in] len    The length in bytes of the requested buffer.
+   * @param[in] read_only Set to true for a read only buffer.
    * @return A valid shared_buffer smart pointer on success, or an
    * empty smart pointer on failure.
    */
@@ -74,6 +75,7 @@ class shared_buffer {
    * @param[in] base The base of the pre-allocated memory.
    * @param[in] len The size of the pre-allocated memory,
    * which must be a multiple of the page size.
+   * @param[in] read_only Set to true for a read only buffer.
    * @return A valid shared_buffer smart pointer on success, or an
    * empty smart pointer on failure.
    */

--- a/include/opae/metrics.h
+++ b/include/opae/metrics.h
@@ -116,11 +116,11 @@ fpga_result fpgaGetMetricsByName(fpga_handle handle,
  * Retrieve metrics / sendor threshold information and values
  *
  * @param[in] handle Handle to previously opened fpga resource
- * @param[inout] metrics_threshold pointer to array of metric thresholds
+ * @param[inout] metric_thresholds Pointer to array of metric thresholds
  * user allocates threshold array memory
  * Number of thresholds returns enumerated thresholds if user pass
  * NULL metrics_thresholds
- * @param[inout] num_thresholds number of thresholds
+ * @param[inout] num_thresholds Number of thresholds
  *
  *
  * @returns FPGA_OK on success. FPGA_NOT_FOUND if the Metrics are not

--- a/include/opae/vfio.h
+++ b/include/opae/vfio.h
@@ -366,6 +366,7 @@ enum opae_vfio_buffer_flags {
  *                      to ignore.
  * @param[out]     iova Optional pointer to receive the IOVA address
  *                      for the buffer. Pass NULL to ignore.
+ * @param[in]     flags Flags for allocation (e.g. OPAE_VFIO_BUF_PREALLOCATED).
  * @returns Non-zero on error. Zero on success.
  *
  * Example


### PR DESCRIPTION
Add --force and --enable-sriov options to the subparser for opae.io init. The --force option enables controlling the force parameter to vfio_init() that was previously hard-coded to False.

The --enable-sriov option, when given, causes opae.io init to write 'Y' to /sys/module/vfio_pci/parameters/enable_sriov.

The default value for both options is False.

*PR Title should start with one of the following tags: [Fix]/[Feature]/[Style]/[Update]*

*[Fix]- Bug Fix*

*[Feature]- for new feature*

*[Style]- Grammar or branding fix*

*[Update]-For an update to an existing feature*

------------- *Keep everything below this line* -------------------------

### Description
*Describe the issue, update, change or fix and **why***


### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
