### PR TITLE
[Feature] - Add support for multi-port AFUs in OPAE vfio plugin

### DIFF
--- a/include/opae/access.h
+++ b/include/opae/access.h
@@ -58,6 +58,12 @@ extern "C" {
  *                          when all associated handles have been closed
  *                          (either explicitly with fpgaClose() or by process
  *                          termination).
+ *                        * FPGA_OPEN_HAS_PARENT_AFU is currently supported only
+ *                          inside OPAE, between the shell and a plugin. It
+ *                          indicates that the resource being opened is a child
+ *                          of a parent resource that is already open in the
+ *                          same process. When set, the value of *handle on
+ *                          entry is the parent handle.
  * @returns             FPGA_OK on success. FPGA_NOT_FOUND if the resource for
  *                      'token' could not be found. FPGA_INVALID_PARAM if
  *                      'token' does not refer to a resource that can be

--- a/include/opae/mem_alloc.h
+++ b/include/opae/mem_alloc.h
@@ -169,6 +169,20 @@ int mem_alloc_get(struct mem_alloc *m,
 int mem_alloc_put(struct mem_alloc *m,
 		  uint64_t address);
 
+/** Apply free list constraints from a second allocator.
+ *
+ * Apply the memory region constraints from the free
+ * list of m_constr to the m allocator object. After the
+ * call, all of allocator m's free address ranges are
+ * guaranteed to be within free ranges also found in m_constr.
+ *
+ * @param[in, out] m        The memory allocator object.
+ * @param[in]      m_constr A second allocator with new constraints.
+ * @returns Non-zero on error. Zero on success.
+ */
+int mem_alloc_apply_constraint(struct mem_alloc *m,
+			       struct mem_alloc *m_constr);
+
 #ifdef __cplusplus
 }
 #endif // __cplusplus

--- a/include/opae/types_enum.h
+++ b/include/opae/types_enum.h
@@ -155,7 +155,9 @@ enum fpga_buffer_flags {
  */
 enum fpga_open_flags {
 	/** Open FPGA resource for shared access */
-	FPGA_OPEN_SHARED = (1u << 0)
+	FPGA_OPEN_SHARED = (1u << 0),
+	/** FPGA resource being opened has a parent in the same address space */
+	FPGA_OPEN_HAS_PARENT_AFU = (1u << 1)
 };
 
 /**

--- a/include/opae/vfio.h
+++ b/include/opae/vfio.h
@@ -225,6 +225,24 @@ int opae_vfio_secure_open(struct opae_vfio *v,
 			  const char *token);
 
 /**
+ * Note a new contraint on the group's IOVA space.
+ *
+ * OPAE does not yet attempt to connect multiple groups to the same vfio
+ * container. When multiple groups and containers are active in the same
+ * process, OPAE instead treats one container as the parent and applies
+ * the IOVA contraints of all other containers to the parent. This way,
+ * an IOVA choice in the parent is guaranteed legal in all groups.
+ * For now, the IOMMU has to be configured for each device but the
+ * same IOVA can be used because of the constraint managed here.
+ *
+ * @param[in] new_v  New source of IOVA constraints.
+ * @param[in] v      Apply constraints to this container.
+ * @returns Non-zero on error. Zero on success.
+ */
+int opae_vfio_apply_group_constraint(struct opae_vfio *new_v,
+				     struct opae_vfio *v);
+
+/**
  * Query device MMIO region
  *
  * Retrieves info describing the MMIO region with the given region index.
@@ -447,6 +465,41 @@ struct opae_vfio_buffer *opae_vfio_buffer_info(struct opae_vfio *v,
  */
 int opae_vfio_buffer_free(struct opae_vfio *v,
 			  uint8_t *buf);
+
+/**
+ * Map an existing buffer for DMA at iova.
+ *
+ * Similar to opae_vfio_buffer_allocate_ex(), except that the
+ * iova is chosen by the caller and the buffer must already
+ * be allocated. The OPAE vfio library does not track the
+ * iova. It is the caller's responsibility to ensure the iova
+ * does not conflict. The caller is also responsible for
+ * unmapping with opae_vfio_buffer_unmap().
+ *
+ * @param[in, out] v    The open OPAE VFIO device.
+ * @param[in]      size Buffer size.
+ * @param[out]     buf  Buffer address.
+ * @param[out]     iova IOVA at which buffer should be mapped.
+ * @returns Non-zero on error. Zero on success.
+ */
+int opae_vfio_buffer_map(struct opae_vfio *v,
+			 size_t size,
+			 uint8_t *buf,
+			 uint64_t iova);
+
+/**
+ * Unmap an existing pinned DMA page.
+ *
+ * Undo the effects of opae_vfio_buffer_map().
+ *
+ * @param[in, out] v    The open OPAE VFIO device.
+ * @param[in]      size Buffer size.
+ * @param[out]     iova IOVA at which buffer should be pinned.
+ * @returns Non-zero on error. Zero on success.
+ */
+int opae_vfio_buffer_unmap(struct opae_vfio *v,
+			   size_t size,
+			   uint64_t iova);
 
 /**
  * Enable an IRQ

--- a/libraries/libopae-c/api-shell.c
+++ b/libraries/libopae-c/api-shell.c
@@ -291,6 +291,11 @@ fpga_result __OPAE_API__ fpgaOpen(fpga_token token, fpga_handle *handle,
 	ASSERT_NOT_NULL_RESULT(wrapped_token->adapter_table->fpgaClose,
 			       FPGA_NOT_SUPPORTED);
 
+	if (flags & FPGA_OPEN_HAS_PARENT_AFU) {
+		ASSERT_NOT_NULL(*handle);
+		opae_handle = *handle;
+	}
+
 	res = wrapped_token->adapter_table->fpgaOpen(wrapped_token->opae_token,
 						     &opae_handle, flags);
 

--- a/libraries/libopae-c/multi-port-afu.c
+++ b/libraries/libopae-c/multi-port-afu.c
@@ -179,8 +179,8 @@ fpga_result afu_open_children(opae_wrapped_handle *wrapped_parent_handle)
 			return FPGA_NOT_FOUND;
 		}
 
-		fpga_handle child_handle;
-		result = fpgaOpen(accel_token, &child_handle, 0);
+		fpga_handle child_handle = handle;
+		result = fpgaOpen(accel_token, &child_handle, FPGA_OPEN_HAS_PARENT_AFU);
 		fpgaDestroyToken(&accel_token);
 		if (result != FPGA_OK)
 			return result;

--- a/libraries/plugins/vfio/opae_vfio.h
+++ b/libraries/plugins/vfio/opae_vfio.h
@@ -95,6 +95,7 @@ typedef struct _vfio_pair {
 typedef struct _vfio_handle {
 	uint32_t magic;
 	vfio_token *token;
+	struct _vfio_handle *parent_afu;
 	vfio_pair_t *vfio_pair;
 	volatile uint8_t *mmio_base;
 	size_t mmio_size;

--- a/libraries/plugins/vfio/plugin.c
+++ b/libraries/plugins/vfio/plugin.c
@@ -124,6 +124,12 @@ int __VFIO_API__ opae_plugin_configure(opae_api_adapter_table *adapter,
 		dlsym(adapter->plugin.dl_handle, "vfio_fpgaGetIOAddress");
 	adapter->fpgaBindSVA =
 		dlsym(adapter->plugin.dl_handle, "vfio_fpgaBindSVA");
+	adapter->fpgaPinBuffer =
+		dlsym(adapter->plugin.dl_handle, "vfio_fpgaPinBuffer");
+	adapter->fpgaUnpinBuffer =
+		dlsym(adapter->plugin.dl_handle, "vfio_fpgaUnpinBuffer");
+	adapter->fpgaGetWSInfo =
+		dlsym(adapter->plugin.dl_handle, "vfio_fpgaGetWSInfo");
 	adapter->fpgaCreateEventHandle =
 		dlsym(adapter->plugin.dl_handle, "vfio_fpgaCreateEventHandle");
 	adapter->fpgaDestroyEventHandle =


### PR DESCRIPTION
### Description
Multi-port AFUs connect to more than one device from a single process, sharing IOVA space across all devices.