### PR TITLE
fix: (Cherry-pick) fpgasudpate maximum progress bar calculations to 100%. (#3078)

### DIFF
--- a/python/opae.admin/opae/admin/tools/fpgasupdate.py
+++ b/python/opae.admin/opae/admin/tools/fpgasupdate.py
@@ -699,6 +699,9 @@ def update_fw_sysfs(infile, pac):
 
     retries = 0
     max_retries = 60 * 60 * 3
+    if estimated_time < timeout:
+       estimated_time = timeout
+
     with progress(time=estimated_time, **progress_cfg) as prg:
         while status.value in ('writing', 'programming', 'transferring'):
             time.sleep(timeout)


### PR DESCRIPTION
fpgasudpate estimated time (0.04 seconds) less than a timeout( 1 second), the progress bar shows 100%.
  set the estimated time to timeout if the estimated time is below 1 second (progress time set to 100%).

