### PR TITLE
fix: (Cherry-pick) update CXL Host exerciser latency calculations (#3088)

### DIFF
--- a/samples/cxl_host_exerciser/cxl_he_cache_cmd.h
+++ b/samples/cxl_host_exerciser/cxl_he_cache_cmd.h
@@ -272,9 +272,9 @@ public:
                 return -1;
             }
 
-            total_latency = total_latency + get_ticks();
+            total_latency = total_latency + get_ticks() - get_penalty_start_ticks();
             host_exe_->logger_->info("Iteration: {0}  Latency: {1:0.3f} nanoseconds",
-                i, (double)(get_ticks() * LATENCY_FACTOR));
+                i, (double)((get_ticks()- get_penalty_start_ticks()) * LATENCY_FACTOR));
         } //end for loop
 
         total_latency = total_latency * LATENCY_FACTOR;
@@ -556,9 +556,9 @@ public:
                 return -1;
             }
 
-            total_latency = total_latency + get_ticks();
+            total_latency = total_latency + get_ticks() - get_penalty_start_ticks();
             host_exe_->logger_->info("Iteration: {0}  Latency: {1:0.3f} nanoseconds",
-                i, (double)(get_ticks() * LATENCY_FACTOR));
+                i, (double)((get_ticks() - get_penalty_start_ticks() ) * LATENCY_FACTOR));
         } //end for loop
 
         total_latency = total_latency * LATENCY_FACTOR;
@@ -793,9 +793,9 @@ public:
                 return -1;
             }
 
-            total_latency = total_latency + get_ticks();
+            total_latency = total_latency + get_ticks() - get_penalty_start_ticks();
             host_exe_->logger_->info("Iteration: {0}  Latency: {1:0.3f} nanoseconds",
-                i, (double)(get_ticks() * LATENCY_FACTOR));
+                i, (double)((get_ticks() - get_penalty_start_ticks() ) * LATENCY_FACTOR));
         } //end for loop
 
         total_latency = total_latency * LATENCY_FACTOR;

--- a/samples/cxl_host_exerciser/cxl_he_cmd.h
+++ b/samples/cxl_host_exerciser/cxl_he_cmd.h
@@ -352,6 +352,19 @@ public:
           return 0;
   }
 
+  uint64_t get_penalty_start_ticks() {
+      volatile he_cache_dsm_status* dsm_status = NULL;
+
+      dsm_status = reinterpret_cast<he_cache_dsm_status*>(
+          (uint8_t*)(host_exe_->get_dsm()));
+      if (!dsm_status)
+          return 0;
+      if (dsm_status->penalty_start > 0)
+          return dsm_status->penalty_start;
+      else
+          return 0;
+  }
+  
   int  get_mtime(const char* file_name, struct timespec* mtime)
   {
       struct stat s;


### PR DESCRIPTION
-CXL Host exerciser latency calculations  equation by consider the penalty start i.e.
    B asically consider total clock cycles – penalty clock cycles for calculation instead of total cycles that comes in DSM.

    Latency nano seconds  =  (number of ticks – penalty start ticks ) * 2.5

