### PR TITLE
Improve VFIO device enumeration performance

### DIFF
--- a/include/opae/vfio.h
+++ b/include/opae/vfio.h
@@ -163,6 +163,26 @@ extern "C" {
 #endif
 
 /**
+ * Confirm that a device is available (not already open).
+ *
+ * Opens the PCIe device corresponding to the address given in pciaddr.
+ * The device must be bound to the vfio-pci driver prior to opening it.
+ * The data structures corresponding to IOVA space, MMIO regions,
+ * and DMA buffers are initialized.
+ *
+ * @param[in]  pciaddr The PCIe address of the requested device.
+ * @returns Non-zero when device is busy. Zero on success.
+ *
+ * Example
+ * @code{.c}
+ * if (opae_vfio_dev_busy("0000:00:00.0")) {
+ *   // handle error
+ * }
+ * @endcode
+ */
+int opae_vfio_dev_busy(const char *pciaddr);
+
+/**
  * Open and populate a VFIO device
  *
  * Opens the PCIe device corresponding to the address given in pciaddr.

--- a/libraries/libopaevfio/opaevfio.c
+++ b/libraries/libopaevfio/opaevfio.c
@@ -1276,6 +1276,26 @@ out_destroy_attr:
 	return res;
 }
 
+int opae_vfio_dev_busy(const char *pciaddr)
+{
+	char *group = opae_vfio_group_for(pciaddr);
+	if (!group) {
+		ERR("opae_vfio_group_for(\"%s\", O_RDWR)\n", pciaddr);
+		return 1;
+	}
+
+	int fd = opae_open(group, O_RDWR);
+	if (fd < 0) {
+		ERR("open(\"%s\", O_RDWR)\n", group);
+		opae_free(group);
+		return 2;
+	}
+
+	opae_free(group);
+	opae_close(fd);
+	return 0;
+}
+
 int opae_vfio_open(struct opae_vfio *v,
 		   const char *pciaddr)
 {

--- a/libraries/plugins/vfio/opae_vfio.c
+++ b/libraries/plugins/vfio/opae_vfio.c
@@ -585,6 +585,20 @@ STATIC fpga_result vfio_reset(const vfio_pci_device_t *dev,
 	return FPGA_OK;
 }
 
+STATIC uint32_t vfio_irq_count(struct opae_vfio *device)
+{
+	struct opae_vfio_device_irq *irq =
+		device->device.irqs;
+
+	while (irq) {
+		if (irq->index == VFIO_PCI_MSIX_IRQ_INDEX)
+			return irq->count;
+		irq = irq->next;
+	}
+
+	return 0;
+}
+
 STATIC int vfio_walk(vfio_pci_device_t *dev)
 {
 	int res = 0;
@@ -649,6 +663,7 @@ STATIC int vfio_walk(vfio_pci_device_t *dev)
 	tok->user_mmio_count = 1;
 	tok->user_mmio[bar] = 0;
 	tok->ops.reset = vfio_reset;
+	tok->num_afu_irqs = vfio_irq_count(v);
 	vfio_get_guid(1+(uint64_t *)mmio, tok->hdr.guid);
 
 	// only check BAR 0 for an FPGA_ACCELERATOR, skip other BARs
@@ -881,9 +896,6 @@ fpga_result __VFIO_API__ vfio_fpgaUpdateProperties(fpga_token token, fpga_proper
 	SET_FIELD_VALID(_prop, FPGA_PROPERTY_INTERFACE);
 
 	if (t->hdr.objtype == FPGA_ACCELERATOR) {
-		fpga_result res;
-		vfio_pair_t *pair = NULL;
-
 		_prop->parent = NULL;
 		CLEAR_FIELD_VALID(_prop, FPGA_PROPERTY_PARENT);
 
@@ -897,9 +909,7 @@ fpga_result __VFIO_API__ vfio_fpgaUpdateProperties(fpga_token token, fpga_proper
 		SET_FIELD_VALID(_prop, FPGA_PROPERTY_NUM_INTERRUPTS);
 
 		SET_FIELD_VALID(_prop, FPGA_PROPERTY_ACCELERATOR_STATE);
-		res = open_vfio_pair(t->device->addr, &pair);
-		if (res == FPGA_OK) {
-			close_vfio_pair(&pair);
+		if (!opae_vfio_dev_busy(t->device->addr)) {
 			_prop->u.accelerator.state =
 				t->afu_state = FPGA_ACCELERATOR_UNASSIGNED;
 		} else {
@@ -1377,20 +1387,6 @@ STATIC bool matches_filters(const fpga_properties *filters,
 	return false;
 }
 
-STATIC uint32_t vfio_irq_count(struct opae_vfio *device)
-{
-	struct opae_vfio_device_irq *irq =
-		device->device.irqs;
-
-	while (irq) {
-		if (irq->index == VFIO_PCI_MSIX_IRQ_INDEX)
-			return irq->count;
-		irq = irq->next;
-	}
-
-	return 0;
-}
-
 fpga_result __VFIO_API__ vfio_fpgaEnumerate(const fpga_properties *filters,
 			       uint32_t num_filters, fpga_token *tokens,
 			       uint32_t max_tokens, uint32_t *num_matches)
@@ -1402,13 +1398,13 @@ fpga_result __VFIO_API__ vfio_fpgaEnumerate(const fpga_properties *filters,
 		if (pci_matches_filters(filters, num_filters, dev)) {
 			vfio_token *tptr;
 
-			vfio_walk(dev);
+			// Walk the device if it hasn't been seen yet
+			if (!dev->tokens)
+				vfio_walk(dev);
+
 			tptr = dev->tokens;
 
 			while (tptr) {
-				vfio_pair_t *pair = NULL;
-				fpga_result res;
-
 				tptr->hdr.vendor_id = (uint16_t)tptr->device->vendor;
 				tptr->hdr.device_id = (uint16_t)tptr->device->device;
 				tptr->hdr.subsystem_vendor_id = tptr->device->subsystem_vendor;
@@ -1423,15 +1419,10 @@ fpga_result __VFIO_API__ vfio_fpgaEnumerate(const fpga_properties *filters,
 				if (tptr->hdr.objtype == FPGA_DEVICE)
 					memcpy(tptr->hdr.guid, tptr->compat_id, sizeof(fpga_guid));
 
-				res = open_vfio_pair(tptr->device->addr, &pair);
-				if (res == FPGA_OK) {
-					tptr->num_afu_irqs = vfio_irq_count(pair->device);
-
-					close_vfio_pair(&pair);
+				if (!opae_vfio_dev_busy(tptr->device->addr))
 					tptr->afu_state = FPGA_ACCELERATOR_UNASSIGNED;
-				} else {
+				else
 					tptr->afu_state = FPGA_ACCELERATOR_ASSIGNED;
-				}
 
 				if (matches_filters(filters, num_filters, tptr)) {
 					if (matches < max_tokens) {


### PR DESCRIPTION
### Description
- Use results of earlier device walks instead of reopening devices.
- Add a lightweight check for busy devices.
