### PR TITLE
pacsign: hide confusing log message

### DIFF
--- a/python/pacsign/pacsign/hsm_managers/openssl/openssl.py
+++ b/python/pacsign/pacsign/hsm_managers/openssl/openssl.py
@@ -297,7 +297,7 @@ class openssl:
             try:
                 dll = CDLL(link)
             except OSError:
-                log.warn('CDLL(%s) failed', link)
+                log.debug('CDLL(%s) failed', link)
                 continue
 
             if dll is None:


### PR DESCRIPTION
The openssl hsm_manager looks for a list of possible versions for libcrypto. Hide a misleading "failed" message when one of the versions is not found by making it a debug message rather than an warning message.

*PR Title should start with one of the following tags: [Fix]/[Feature]/[Style]/[Update]*

*[Fix]- Bug Fix*

*[Feature]- for new feature*

*[Style]- Grammar or branding fix*

*[Update]-For an update to an existing feature*

------------- *Keep everything below this line* -------------------------

### Description
*Describe the issue, update, change or fix and **why***


### Collateral (docs, reports, design examples, case IDs):



- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
