### PR TITLE
[Fix] - Check memory calibration status before running host_exerciser

### DIFF
--- a/include/opae/cxx/core.h
+++ b/include/opae/cxx/core.h
@@ -31,5 +31,6 @@
 #include <opae/cxx/core/properties.h>
 #include <opae/cxx/core/pvalue.h>
 #include <opae/cxx/core/shared_buffer.h>
+#include <opae/cxx/core/sysobject.h>
 #include <opae/cxx/core/token.h>
 #include <opae/cxx/core/version.h>

--- a/libraries/afu-test/afu_test.h
+++ b/libraries/afu-test/afu_test.h
@@ -215,6 +215,8 @@ public:
 
     filter->type = FPGA_DEVICE;
     auto tokens = fpga::token::enumerate({filter});
+
+    // Error out if the # of tokens != 1
     if (tokens.size() < 1) {
       if (pci_addr_.empty()) {
         logger_->error("no DEVICE found");
@@ -229,6 +231,8 @@ public:
       std::cerr << "more than one DEVICE found matching filter\n";
     }
     int flags = shared_ ? FPGA_OPEN_SHARED : 0;
+    
+    // Open a handle to the resource
     try {
       handle_device_ = fpga::handle::open(tokens[0], flags);
     } catch (fpga::no_access &err) {
@@ -378,8 +382,8 @@ protected:
   std::string log_level_;
   bool shared_;
   uint32_t timeout_msec_;
-  fpga::handle::ptr_t handle_;
-  fpga::handle::ptr_t handle_device_;
+  fpga::handle::ptr_t handle_;                      // Handle for the ACCELERATOR (AFU) resource
+  fpga::handle::ptr_t handle_device_;               // Handle for the DEVICE (FIM) resource
   command::ptr_t current_command_;
   std::map<CLI::App*, command::ptr_t> commands_;
 public:

--- a/libraries/afu-test/afu_test.h
+++ b/libraries/afu-test/afu_test.h
@@ -33,24 +33,30 @@
 #include <random>
 #include <thread>
 
-#include <opae/cxx/core.h>
-#include <spdlog/sinks/basic_file_sink.h>
-#include <spdlog/sinks/stdout_color_sinks.h>
-#include <spdlog/spdlog.h>
 #include <CLI/CLI.hpp>
+#include <spdlog/spdlog.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/sinks/basic_file_sink.h>
+#include <opae/cxx/core.h>
 
 const char *sbdf_pattern =
-    "(([0-9a-fA-F]{4}):)?([0-9a-fA-F]{2}):([0-9a-fA-F]{2})\\.([0-9])";
+  "(([0-9a-fA-F]{4}):)?([0-9a-fA-F]{2}):([0-9a-fA-F]{2})\\.([0-9])";
 
-enum { MATCHES_SIZE = 6 };
+enum {
+  MATCHES_SIZE = 6
+};
+
 
 namespace opae {
 namespace afu_test {
 
 namespace fpga = fpga::types;
 
-template <typename T>
-inline bool parse_match_int(const char *s, regmatch_t m, T &v, int radix = 10) {
+
+template<typename T>
+inline bool parse_match_int(const char *s,
+                            regmatch_t m, T &v, int radix=10)
+{
   if (m.rm_so == -1 || m.rm_eo == -1) return false;
   errno = 0;
   v = std::strtoul(s + m.rm_so, NULL, radix);
@@ -59,15 +65,16 @@ inline bool parse_match_int(const char *s, regmatch_t m, T &v, int radix = 10) {
 
 union pcie_address {
   struct {
-    uint32_t function : 3;
-    uint32_t device : 5;
+    uint32_t function: 3;
+    uint32_t device: 5;
     uint32_t bus : 8;
     uint32_t domain : 16;
   } fields;
   uint32_t value;
 
-  static pcie_address parse(const char *s) {
-    auto deleter = [&](regex_t *r) {
+  static pcie_address parse(const char *s)
+  {
+    auto deleter = [&](regex_t *r){
       regfree(r);
       delete r;
     };
@@ -75,13 +82,16 @@ union pcie_address {
     regmatch_t matches[MATCHES_SIZE];
 
     int reg_res = regcomp(re.get(), sbdf_pattern, REG_EXTENDED | REG_ICASE);
-    if (reg_res) throw std::runtime_error("could not compile regex");
+    if (reg_res)
+      throw std::runtime_error("could not compile regex");
 
     reg_res = regexec(re.get(), s, MATCHES_SIZE, matches, 0);
-    if (reg_res) throw std::runtime_error("pcie address not valid format");
+    if (reg_res)
+      throw std::runtime_error("pcie address not valid format");
 
     uint16_t domain, bus, device, function;
-    if (!parse_match_int(s, matches[2], domain, 16)) domain = 0;
+    if (!parse_match_int(s, matches[2], domain, 16))
+      domain = 0;
     if (!parse_match_int(s, matches[3], bus, 16))
       throw std::runtime_error("error parsing pcie address");
     if (!parse_match_int(s, matches[4], device, 16))
@@ -89,31 +99,38 @@ union pcie_address {
     if (!parse_match_int(s, matches[5], function))
       throw std::runtime_error("error parsing; pcie address");
     pcie_address a;
-    a.fields.domain = domain;
-    a.fields.bus = bus;
-    a.fields.device = device;
-    a.fields.function = function;
+    a.fields.domain=domain;
+    a.fields.bus=bus;
+    a.fields.device=device;
+    a.fields.function=function;
     return a;
   }
+
 };
 
-class afu;  // forward declaration
+class afu; // forward declaration
 
 class command {
- public:
+public:
   typedef std::shared_ptr<command> ptr_t;
   command() : running_(true) {}
-  virtual ~command() {}
+  virtual ~command(){}
   virtual const char *name() const = 0;
   virtual const char *description() const = 0;
   virtual int run(afu *afu, CLI::App *app) = 0;
-  virtual void add_options(CLI::App *app) { (void)app; }
-  virtual const char *afu_id() const { return nullptr; }
+  virtual void add_options(CLI::App *app)
+  {
+    (void)app;
+  }
+  virtual const char *afu_id() const
+  {
+    return nullptr;
+  }
 
   bool running() const { return running_; }
   void stop() { running_ = false; }
 
- private:
+private:
   std::atomic<bool> running_;
 };
 
@@ -121,20 +138,21 @@ class command {
 // spdlog version 1.9.0 defines SPDLOG_LEVEL_NAMES as an array of string_view_t.
 // Convert to vector of std::string to be used in CLI::IsMember().
 inline std::vector<std::string> spdlog_levels() {
-  std::vector<spdlog::string_view_t> levels_view = SPDLOG_LEVEL_NAMES;
-  std::vector<std::string> levels_str(levels_view.size());
-  std::transform(levels_view.begin(), levels_view.end(), levels_str.begin(),
-                 [](spdlog::string_view_t sv) {
-                   return std::string(sv.data(), sv.size());
-                 });
-  return levels_str;
+    std::vector<spdlog::string_view_t> levels_view = SPDLOG_LEVEL_NAMES;
+    std::vector<std::string> levels_str(levels_view.size());
+    std::transform(levels_view.begin(), levels_view.end(),
+                   levels_str.begin(),
+                   [](spdlog::string_view_t sv) {
+                     return std::string(sv.data(), sv.size());
+                   });
+    return levels_str;
 }
 #else
 inline std::vector<std::string> spdlog_levels() { return SPDLOG_LEVEL_NAMES; }
-#endif  // SPDLOG_VERSION
+#endif // SPDLOG_VERSION
 
 class afu {
- public:
+public:
   typedef int (*command_fn)(afu *afu, CLI::App *app);
   enum exit_codes {
     success = 0,
@@ -145,47 +163,48 @@ class afu {
     error
   };
 
-  afu(const char *name, const char *afu_id = nullptr,
-      const char *log_level = nullptr)
-      : name_(name),
-        afu_id_(afu_id ? afu_id : ""),
-        app_(name_),
-        pci_addr_(""),
-        log_level_(log_level ? log_level : "info"),
-        shared_(false),
-        timeout_msec_(60000),
-        handle_(nullptr),
-        current_command_(nullptr) {
+  afu(const char *name, const char *afu_id = nullptr, const char *log_level = nullptr)
+  : name_(name)
+  , afu_id_(afu_id ? afu_id : "")
+  , app_(name_)
+  , pci_addr_("")
+  , log_level_(log_level ? log_level : "info")
+  , shared_(false)
+  , timeout_msec_(60000)
+  , handle_(nullptr)
+  , current_command_(nullptr)
+  {
     if (!afu_id_.empty())
       app_.add_option("-g,--guid", afu_id_, "GUID")->default_str(afu_id_);
     app_.add_option("-p,--pci-address", pci_addr_,
                     "[<domain>:]<bus>:<device>.<function>");
-    app_.add_option("-l,--log-level", log_level_, "stdout logging level")
-        ->default_str(log_level_)
-        ->check(CLI::IsMember(spdlog_levels()));
-    app_.add_flag("-s,--shared", shared_,
-                  "open in shared mode, default is off");
-    app_.add_option("-t,--timeout", timeout_msec_, "test timeout (msec)")
-        ->default_str(std::to_string(timeout_msec_));
+    app_.add_option("-l,--log-level", log_level_, "stdout logging level")->
+      default_str(log_level_)->
+      check(CLI::IsMember(spdlog_levels()));
+    app_.add_flag("-s,--shared", shared_, "open in shared mode, default is off");
+    app_.add_option("-t,--timeout", timeout_msec_, "test timeout (msec)")->default_str(std::to_string(timeout_msec_));
   }
   virtual ~afu() {
-    if (logger_) spdlog::drop(logger_->name());
+    if (logger_)
+      spdlog::drop(logger_->name());
   }
 
-  CLI::App &cli() { return app_; }
+  CLI::App & cli() { return app_; }
 
-  fpga::properties::ptr_t afu_properties() const {
+  fpga::properties::ptr_t afu_properties() const
+  {
     return fpga::properties::get(handle_);
   }
 
   int open_handle(const char *afu_id) {
-    auto filter = fpga::properties::get();  // Get an empty properties object
+    
+    auto filter = fpga::properties::get(); // Get an empty properties object
 
     // The following code attempts to get a token+handle for the DEVICE.
     // This is to allow access to OPAE-API functions that are only supported
     // through the xfpga plugin (i.e accessing sysfs entries)
     // In contrast, the ACCELERATOR token may be underlied by the vfio plugin.
-
+    
     if (!pci_addr_.empty()) {
       auto p = pcie_address::parse(pci_addr_.c_str());
       filter->segment = p.fields.domain;
@@ -196,22 +215,19 @@ class afu {
 
     filter->type = FPGA_DEVICE;
     auto tokens = fpga::token::enumerate({filter});
-
-    // Check if the number of tokens != 1 and error out.
     if (tokens.size() < 1) {
       if (pci_addr_.empty()) {
         logger_->error("no DEVICE found");
       } else {
-        logger_->error("no accelerator found at PCIe address {1}", pci_addr_);
+        logger_->error("no accelerator found at PCIe address {1}",
+            pci_addr_);
       }
       return exit_codes::not_found;
-    }
+    }    
 
     if (tokens.size() > 1) {
       std::cerr << "more than one DEVICE found matching filter\n";
     }
-
-    // Get a handle to the resource represented by the token
     int flags = shared_ ? FPGA_OPEN_SHARED : 0;
     try {
       handle_device_ = fpga::handle::open(tokens[0], flags);
@@ -220,14 +236,14 @@ class afu {
       return exit_codes::no_access;
     }
 
-    // The following code attempts to get a token + handle for the AFU
+    // The following code attempts to get a token + handle for the AFU 
     // (ACCELERATOR device) matching the given command's afu_id.
     // We reuse the PCIe SBDF addressing from above.
     auto app_afu_id = afu_id ? afu_id : afu_id_.c_str();
     filter->type = FPGA_ACCELERATOR;
     try {
       filter->guid.parse(app_afu_id);
-    } catch (opae::fpga::types::except &err) {
+    } catch(opae::fpga::types::except & err) {
       return error;
     }
 
@@ -237,7 +253,7 @@ class afu {
         logger_->error("no accelerator found with id: {0}", app_afu_id);
       } else {
         logger_->error("no accelerator found with id: {0} at PCIe address {1}",
-                       app_afu_id, pci_addr_);
+            app_afu_id, pci_addr_);
       }
       return exit_codes::not_found;
     }
@@ -245,7 +261,7 @@ class afu {
     if (tokens.size() > 1) {
       std::cerr << "more than one accelerator found matching filter\n";
     }
-
+    
     try {
       handle_ = fpga::handle::open(tokens[0], flags);
     } catch (fpga::no_access &err) {
@@ -256,8 +272,10 @@ class afu {
     return exit_codes::not_run;
   }
 
-  int main(int argc, char *argv[]) {
-    if (!commands_.empty()) app_.require_subcommand();
+  int main(int argc, char *argv[])
+  {
+    if (!commands_.empty())
+      app_.require_subcommand();
     CLI11_PARSE(app_, argc, argv);
 
     command::ptr_t test(nullptr);
@@ -287,15 +305,17 @@ class afu {
     return run(app, test);
   }
 
-  virtual int run(CLI::App *app, command::ptr_t test) {
+  virtual int run(CLI::App *app, command::ptr_t test)
+  {
     int res = exit_codes::not_run;
 
     current_command_ = test;
 
     try {
-      std::future<int> f = std::async(std::launch::async, [this, test, app]() {
-        return test->run(this, app);
-      });
+      std::future<int> f = std::async(std::launch::async,
+        [this, test, app](){
+          return test->run(this, app);
+        });
       auto status = f.wait_for(std::chrono::milliseconds(timeout_msec_));
       if (status == std::future_status::timeout) {
         std::cerr << "Error: test timed out" << std::endl;
@@ -303,7 +323,7 @@ class afu {
         throw std::runtime_error("timeout");
       }
       res = f.get();
-    } catch (std::exception &ex) {
+    } catch(std::exception &ex) {
       res = exit_codes::exception;
     }
 
@@ -311,34 +331,46 @@ class afu {
     return res;
   }
 
-  template <class T>
-  CLI::App *register_command() {
+  template<class T>
+  CLI::App *register_command()
+  {
     command::ptr_t cmd(new T());
-    auto sub = app_.add_subcommand(cmd->name(), cmd->description());
+    auto sub = app_.add_subcommand(cmd->name(),
+                                   cmd->description());
     cmd->add_options(sub);
     commands_[sub] = cmd;
     return sub;
   }
 
-  fpga::handle::ptr_t handle() const { return handle_; }
+  fpga::handle::ptr_t handle() const {
+    return handle_;
+  }
 
-  fpga::handle::ptr_t handle_device() const { return handle_device_; }
+  fpga::handle::ptr_t handle_device() const {
+    return handle_device_;
+  }
 
-  uint64_t read64(uint32_t offset) const { return handle_->read_csr64(offset); }
+  uint64_t read64(uint32_t offset) const {
+    return handle_->read_csr64(offset);
+  }
 
   void write64(uint32_t offset, uint64_t value) const {
     return handle_->write_csr64(offset, value);
   }
 
-  uint32_t read32(uint32_t offset) const { return handle_->read_csr32(offset); }
+  uint32_t read32(uint32_t offset) const {
+    return handle_->read_csr32(offset);
+  }
 
   void write32(uint32_t offset, uint32_t value) const {
     return handle_->write_csr32(offset, value);
   }
 
-  command::ptr_t current_command() const { return current_command_; }
+  command::ptr_t current_command() const {
+    return current_command_;
+  }
 
- protected:
+protected:
   std::string name_;
   std::string afu_id_;
   CLI::App app_;
@@ -346,15 +378,15 @@ class afu {
   std::string log_level_;
   bool shared_;
   uint32_t timeout_msec_;
-  fpga::handle::ptr_t handle_;  // Handle for ACCELERATOR resource (i.e. an AFU)
-  fpga::handle::ptr_t
-      handle_device_;  // Handle for DEVICE resource (i.e. the FIM)
+  fpga::handle::ptr_t handle_;
+  fpga::handle::ptr_t handle_device_;
   command::ptr_t current_command_;
-  std::map<CLI::App *, command::ptr_t> commands_;
-
- public:
+  std::map<CLI::App*, command::ptr_t> commands_;
+public:
   std::shared_ptr<spdlog::logger> logger_;
 };
 
-}  // end of namespace afu_test
-}  // end of namespace opae
+
+} // end of namespace afu_test
+} // end of namespace opae
+

--- a/samples/host_exerciser/host_exerciser.h
+++ b/samples/host_exerciser/host_exerciser.h
@@ -44,7 +44,9 @@ static const uint64_t LOG2_CL = 6;
 static const size_t LPBK1_DSM_SIZE = 2 * KB;
 static const size_t LPBK1_BUFFER_SIZE = 64 * KB;
 static const size_t LPBK1_BUFFER_ALLOCATION_SIZE = 64 * KB;
-static const size_t MAX_NUM_MEM_CHANNELS = 8; // The maximum number of assumed memory channels created by the dfl-emif driver. 
+static const size_t MAX_NUM_MEM_CHANNELS =
+    8;  // The maximum number of assumed memory channels created by the dfl-emif
+        // driver.
 
 // Host execiser CSR Offset
 enum {
@@ -73,7 +75,7 @@ enum {
   HE_INFO0 = 0x0180,
 };
 
-//configures test mode
+// configures test mode
 typedef enum {
   HOST_EXEMODE_LPBK1 = 0x0,
   HOST_EXEMODE_READ = 0x1,
@@ -81,7 +83,7 @@ typedef enum {
   HOST_EXEMODE_TRPUT = 0x3,
 } host_exe_mode;
 
-//request cache line
+// request cache line
 typedef enum {
   HOSTEXE_CLS_1 = 0x0,
   HOSTEXE_CLS_2 = 0x1,
@@ -90,7 +92,7 @@ typedef enum {
   HOSTEXE_CLS_16 = 0x4,
 } hostexe_req_len;
 
-//configures atomic transactions
+// configures atomic transactions
 typedef enum {
   // Bit 0 enables atomic function mode
   // Bit 1 selects 4 byte or 8 byte requests
@@ -104,7 +106,7 @@ typedef enum {
   HOSTEXE_ATOMIC_CAS_8 = 0xb,
 } hostexe_atomic_func;
 
-//configures data mover vs. power user encoding of requests
+// configures data mover vs. power user encoding of requests
 typedef enum {
   HOSTEXE_ENCODING_DEFAULT = 0x0,  // Use the RTL PU_MEM_REQ parameter
   HOSTEXE_ENCODING_DM = 0x1,       // Only data mover
@@ -112,35 +114,29 @@ typedef enum {
   HOSTEXE_ENCODING_RANDOM = 0x3,   // Both DM and PU in the same stream
 } hostexe_encoding;
 
-//he test type
+// he test type
 typedef enum {
   HOSTEXE_TEST_ROLLOVER = 0x0,
   HOSTEXE_TEST_TERMINATION = 0x1,
 } hostexe_test_mode;
 
-
 // DFH Header
-union he_dfh  {
-  enum {
-    offset = HE_DFH
-  };
+union he_dfh {
+  enum { offset = HE_DFH };
   uint64_t value;
   struct {
     uint16_t CcipVersionNumber : 12;
-    uint8_t  AfuMajVersion : 4;
+    uint8_t AfuMajVersion : 4;
     uint32_t NextDfhOffset : 24;
-    uint8_t  EOL : 1;
+    uint8_t EOL : 1;
     uint32_t Reserved : 19;
-    uint8_t  FeatureType : 4;
+    uint8_t FeatureType : 4;
   };
 };
 
-
 // DSM BASEL
 union he_dsm_basel {
-  enum {
-    offset = HE_DSM_BASEL
-  };
+  enum { offset = HE_DSM_BASEL };
   uint32_t value;
   struct {
     uint32_t DsmBaseL : 32;
@@ -149,9 +145,7 @@ union he_dsm_basel {
 
 // DSM BASEH
 union he_dsm_baseh {
-  enum {
-    offset = HE_DSM_BASEH
-  };
+  enum { offset = HE_DSM_BASEH };
   uint32_t value;
   struct {
     uint32_t DsmBaseH : 32;
@@ -160,9 +154,7 @@ union he_dsm_baseh {
 
 // NUM_LINES
 union he_num_lines {
-  enum {
-    offset = HE_NUM_LINES
-  };
+  enum { offset = HE_NUM_LINES };
   uint32_t value;
   struct {
     uint32_t NumCacheLines : 32;
@@ -170,12 +162,9 @@ union he_num_lines {
   };
 };
 
-
 // CSR CTL
-union he_ctl{
-  enum {
-    offset = HE_CTL
-  };
+union he_ctl {
+  enum { offset = HE_CTL };
   uint32_t value;
   struct {
     uint32_t ResetL : 1;
@@ -185,12 +174,9 @@ union he_ctl{
   };
 };
 
-
 // CSR CFG
 union he_cfg {
-  enum {
-    offset = HE_CFG
-  };
+  enum { offset = HE_CFG };
   uint64_t value;
   struct {
     uint64_t DelayEn : 1;
@@ -211,9 +197,7 @@ union he_cfg {
 
 // CSR INACT THRESH
 union he_inact_thresh {
-  enum {
-    offset = HE_INACT_THRESH
-  };
+  enum { offset = HE_INACT_THRESH };
   uint32_t value;
   struct {
     uint32_t InactivtyThreshold : 32;
@@ -222,9 +206,7 @@ union he_inact_thresh {
 
 // INTERRUPT0
 union he_interrupt0 {
-  enum {
-    offset = HE_INTERRUPT0
-  };
+  enum { offset = HE_INTERRUPT0 };
   uint32_t value;
   struct {
     uint32_t apci_id : 16;
@@ -234,9 +216,7 @@ union he_interrupt0 {
 
 // SWTEST MSG
 union he_swtest_msg {
-  enum {
-    offset = HE_SWTEST_MSG
-  };
+  enum { offset = HE_SWTEST_MSG };
   uint64_t value;
   struct {
     uint64_t swtest_msg : 64;
@@ -245,9 +225,7 @@ union he_swtest_msg {
 
 // STATUS0
 union he_status0 {
-  enum {
-    offset = HE_STATUS0
-  };
+  enum { offset = HE_STATUS0 };
   uint64_t value;
   struct {
     uint64_t numWrites : 32;
@@ -257,9 +235,7 @@ union he_status0 {
 
 // STATUS1
 union he_status1 {
-  enum {
-    offset = HE_STATUS1
-  };
+  enum { offset = HE_STATUS1 };
   uint64_t value;
   struct {
     uint64_t numPendWrites : 16;
@@ -269,12 +245,9 @@ union he_status1 {
   };
 };
 
-
 // ERROR
 union he_error {
-  enum {
-    offset = HE_ERROR
-  };
+  enum { offset = HE_ERROR };
   uint64_t value;
   struct {
     uint64_t error : 32;
@@ -284,9 +257,7 @@ union he_error {
 
 // STRIDE
 union he_stride {
-  enum {
-    offset = HE_STRIDE
-  };
+  enum { offset = HE_STRIDE };
   uint32_t value;
   struct {
     uint32_t Stride : 32;
@@ -295,35 +266,33 @@ union he_stride {
 
 // HE DSM status
 struct he_dsm_status {
-	uint64_t test_completed : 1;
-	uint64_t dsm_number : 15;
-	uint64_t res1 : 16;
-	uint64_t err_vector : 32;
-	uint64_t num_ticks : 40;
-	uint64_t res2 : 8;
-	uint64_t num_reads_h : 8;
-	uint64_t num_writes_h : 8;
-	uint64_t num_reads_l : 32;
-	uint64_t num_writes_l : 32;
-	uint64_t penalty_start : 16;
-	uint64_t res3 : 16;
-	uint64_t penalty_end : 8;
-	uint64_t res4 : 24;
-	uint64_t ab_error_info : 32;
-	uint32_t res5[7];
+  uint64_t test_completed : 1;
+  uint64_t dsm_number : 15;
+  uint64_t res1 : 16;
+  uint64_t err_vector : 32;
+  uint64_t num_ticks : 40;
+  uint64_t res2 : 8;
+  uint64_t num_reads_h : 8;
+  uint64_t num_writes_h : 8;
+  uint64_t num_reads_l : 32;
+  uint64_t num_writes_l : 32;
+  uint64_t penalty_start : 16;
+  uint64_t res3 : 16;
+  uint64_t penalty_end : 8;
+  uint64_t res4 : 24;
+  uint64_t ab_error_info : 32;
+  uint32_t res5[7];
 };
 
 const std::map<std::string, uint32_t> he_modes = {
-  { "lpbk", HOST_EXEMODE_LPBK1},
-  { "read", HOST_EXEMODE_READ},
-  { "write", HOST_EXEMODE_WRITE},
-  { "trput", HOST_EXEMODE_TRPUT},
+    {"lpbk", HOST_EXEMODE_LPBK1},
+    {"read", HOST_EXEMODE_READ},
+    {"write", HOST_EXEMODE_WRITE},
+    {"trput", HOST_EXEMODE_TRPUT},
 };
 
-struct MapKeyComparator
-{
-  bool operator()( const std::string& a, const std::string& b ) const
-  {
+struct MapKeyComparator {
+  bool operator()(const std::string& a, const std::string& b) const {
     if (a.length() != b.length())
       return (a.length() < b.length());
     else
@@ -332,119 +301,127 @@ struct MapKeyComparator
 };
 
 const std::map<std::string, uint32_t, MapKeyComparator> he_req_cls_len = {
-  { "cl_1", HOSTEXE_CLS_1},
-  { "cl_2", HOSTEXE_CLS_2},
-  { "cl_4", HOSTEXE_CLS_4},
-  { "cl_8", HOSTEXE_CLS_8},
-  { "cl_16", HOSTEXE_CLS_16},
+    {"cl_1", HOSTEXE_CLS_1}, {"cl_2", HOSTEXE_CLS_2},   {"cl_4", HOSTEXE_CLS_4},
+    {"cl_8", HOSTEXE_CLS_8}, {"cl_16", HOSTEXE_CLS_16},
 };
 
 const std::map<std::string, uint32_t> he_req_atomic_func = {
-  { "off", HOSTEXE_ATOMIC_OFF},
-  { "fadd_4", HOSTEXE_ATOMIC_FADD_4},
-  { "fadd_8", HOSTEXE_ATOMIC_FADD_8},
-  { "swap_4", HOSTEXE_ATOMIC_SWAP_4},
-  { "swap_8", HOSTEXE_ATOMIC_SWAP_8},
-  { "cas_4", HOSTEXE_ATOMIC_CAS_4},
-  { "cas_8", HOSTEXE_ATOMIC_CAS_8},
+    {"off", HOSTEXE_ATOMIC_OFF},       {"fadd_4", HOSTEXE_ATOMIC_FADD_4},
+    {"fadd_8", HOSTEXE_ATOMIC_FADD_8}, {"swap_4", HOSTEXE_ATOMIC_SWAP_4},
+    {"swap_8", HOSTEXE_ATOMIC_SWAP_8}, {"cas_4", HOSTEXE_ATOMIC_CAS_4},
+    {"cas_8", HOSTEXE_ATOMIC_CAS_8},
 };
 
 const std::map<std::string, uint32_t> he_req_encoding = {
-  { "default", HOSTEXE_ENCODING_DEFAULT},
-  { "dm", HOSTEXE_ENCODING_DM},
-  { "pu", HOSTEXE_ENCODING_PU},
-  { "random", HOSTEXE_ENCODING_RANDOM},
+    {"default", HOSTEXE_ENCODING_DEFAULT},
+    {"dm", HOSTEXE_ENCODING_DM},
+    {"pu", HOSTEXE_ENCODING_PU},
+    {"random", HOSTEXE_ENCODING_RANDOM},
 };
 
 const std::map<std::string, uint32_t> he_test_mode = {
-  { "test_rollover", HOSTEXE_TEST_ROLLOVER},
-  { "test_termination", HOSTEXE_TEST_TERMINATION}
-};
-
+    {"test_rollover", HOSTEXE_TEST_ROLLOVER},
+    {"test_termination", HOSTEXE_TEST_TERMINATION}};
 
 using test_afu = opae::afu_test::afu;
 using test_command = opae::afu_test::command;
 
 // Inerleave help
-const char *interleave_help = R"desc(Interleave requests pattern to use in throughput mode {0, 1, 2}
+const char* interleave_help =
+    R"desc(Interleave requests pattern to use in throughput mode {0, 1, 2}
 indicating one of the following series of read/write requests:
 0: rd-wr-rd-wr
 1: rd-rd-wr-wr
 2: rd-rd-rd-rd-wr-wr-wr-wr)desc";
 
-
 class host_exerciser : public test_afu {
-public:
-    host_exerciser()
-  : test_afu("host_exerciser", nullptr, "warning")
-  , count_(1)
-  , he_interleave_(0)
-  , he_interrupt_(0xffff)
-  {
+ public:
+  host_exerciser()
+      : test_afu("host_exerciser", nullptr, "warning"),
+        count_(1),
+        he_interleave_(0),
+        he_interrupt_(0xffff) {
     // Mode
-    app_.add_option("-m,--mode", he_modes_, "host exerciser mode {lpbk,read, write, trput}")
-      ->transform(CLI::CheckedTransformer(he_modes))->default_val("lpbk");
+    app_.add_option("-m,--mode", he_modes_,
+                    "host exerciser mode {lpbk,read, write, trput}")
+        ->transform(CLI::CheckedTransformer(he_modes))
+        ->default_val("lpbk");
 
     // Cache line
-    app_.add_option("--cls", he_req_cls_len_, "number of CLs per request{cl_1, cl_2, cl_4, cl_8, cl_16}")
-       ->transform(CLI::CheckedTransformer(he_req_cls_len))->default_val("cl_1");
+    app_.add_option("--cls", he_req_cls_len_,
+                    "number of CLs per request{cl_1, cl_2, cl_4, cl_8, cl_16}")
+        ->transform(CLI::CheckedTransformer(he_req_cls_len))
+        ->default_val("cl_1");
 
     // Configures test rollover or test termination
-    app_.add_option("--continuousmode", he_continuousmode_, "test rollover or test termination")->default_val("false");
+    app_.add_option("--continuousmode", he_continuousmode_,
+                    "test rollover or test termination")
+        ->default_val("false");
 
     // Atomic function
-    app_.add_option("--atomic", he_req_atomic_func_, "atomic requests (only permitted in combination with lpbk/cl_1)")
-      ->transform(CLI::CheckedTransformer(he_req_atomic_func))->default_val("off");
+    app_.add_option(
+            "--atomic", he_req_atomic_func_,
+            "atomic requests (only permitted in combination with lpbk/cl_1)")
+        ->transform(CLI::CheckedTransformer(he_req_atomic_func))
+        ->default_val("off");
 
     // Encoding
-    app_.add_option("--encoding", he_req_encoding_, "data mover or power user encoding -- random interleaves both in the same stream")
-      ->transform(CLI::CheckedTransformer(he_req_encoding))->default_val("default");
+    app_.add_option("--encoding", he_req_encoding_,
+                    "data mover or power user encoding -- random interleaves "
+                    "both in the same stream")
+        ->transform(CLI::CheckedTransformer(he_req_encoding))
+        ->default_val("default");
 
     // Delay
-    app_.add_option("-d,--delay", he_delay_, "Enables random delay insertion between requests")->default_val("false");
+    app_.add_option("-d,--delay", he_delay_,
+                    "Enables random delay insertion between requests")
+        ->default_val("false");
 
     // Configure interleave requests in Throughput mode
-    app_.add_option("--interleave", he_interleave_, interleave_help)->transform(CLI::Range(0, 2));
+    app_.add_option("--interleave", he_interleave_, interleave_help)
+        ->transform(CLI::Range(0, 2));
 
     // The Interrupt Vector Number for the device
     app_.add_option("--interrupt", he_interrupt_,
-        "The Interrupt Vector Number for the device")
+                    "The Interrupt Vector Number for the device")
         ->transform(CLI::Range(0, 4095));
 
-     // Continuous mode time
+    // Continuous mode time
     app_.add_option("--contmodetime", he_contmodetime_,
-        "Continuous mode time in seconds")->default_val("1");
+                    "Continuous mode time in seconds")
+        ->default_val("1");
 
     // Test all
-    app_.add_option("--testall", he_test_all_, "Run all tests")->default_val("false");
+    app_.add_option("--testall", he_test_all_, "Run all tests")
+        ->default_val("false");
 
     app_.add_option("--clock-mhz", he_clock_mhz_,
-        "Clock frequency (MHz) -- when zero, read the frequency from the AFU")->default_val("0");
-   }
+                    "Clock frequency (MHz) -- when zero, read the frequency "
+                    "from the AFU")
+        ->default_val("0");
+  }
 
-  virtual int run(CLI::App *app, test_command::ptr_t test) override
-  {
+  virtual int run(CLI::App* app, test_command::ptr_t test) override {
     int res = exit_codes::not_run;
 
     logger_->set_pattern("    %v");
-    // Info prints details of an individual run. Turn it on if doing only one test
-    // and the user hasn't changed level from the default.
+    // Info prints details of an individual run. Turn it on if doing only one
+    // test and the user hasn't changed level from the default.
     if ((log_level_.compare("warning") == 0) && !he_test_all_)
-        logger_->set_level(spdlog::level::info);
+      logger_->set_level(spdlog::level::info);
 
     logger_->info("starting test run, count of {0:d}", count_);
     uint32_t count = 0;
     try {
       while (count < count_) {
-        logger_->debug("starting iteration: {0:d}", count+1);
-     
+        logger_->debug("starting iteration: {0:d}", count + 1);
+
         res = test_afu::run(app, test);
         count++;
         logger_->debug("end iteration: {0:d}", count);
-        if (res)
-          break;
+        if (res) break;
       }
-    } catch(std::exception &ex) {
+    } catch (std::exception& ex) {
       logger_->error(ex.what());
       res = exit_codes::exception;
     }
@@ -455,94 +432,82 @@ public:
     return res;
   }
 
-  template<typename T>
+  template <typename T>
   inline T read(uint32_t offset) const {
     return *reinterpret_cast<T*>(handle_->mmio_ptr(offset));
   }
 
-  template<typename T>
+  template <typename T>
   inline void write(uint32_t offset, T value) const {
     *reinterpret_cast<T*>(handle_->mmio_ptr(offset)) = value;
   }
 
-  template<typename T>
+  template <typename T>
   T read(uint32_t offset, uint32_t i) const {
     return read<T>(get_offset(offset, i));
   }
 
-  template<typename T>
+  template <typename T>
   void write(uint32_t offset, uint32_t i, T value) const {
     write<T>(get_offset(offset, i), value);
   }
 
-  shared_buffer::ptr_t allocate(size_t size)
-  {
+  shared_buffer::ptr_t allocate(size_t size) {
     return shared_buffer::allocate(handle_, size);
   }
 
-  void fill(shared_buffer::ptr_t buffer)
-  {
+  void fill(shared_buffer::ptr_t buffer) {
     std::random_device rd;
     std::mt19937 mt(rd());
     std::uniform_int_distribution<uint32_t> dist(1, -1);
     auto sz = sizeof(uint32_t);
-    for (uint32_t i = 0; i < buffer->size(); i+=sz){
+    for (uint32_t i = 0; i < buffer->size(); i += sz) {
       buffer->write<uint32_t>(dist(mt), i);
     }
-
   }
 
-  void fill(shared_buffer::ptr_t buffer, uint32_t value)
-  {
+  void fill(shared_buffer::ptr_t buffer, uint32_t value) {
     buffer->fill(value);
   }
 
-  event::ptr_t register_interrupt(uint32_t vector)
-  {
+  event::ptr_t register_interrupt(uint32_t vector) {
     auto event = event::register_event(handle_, FPGA_EVENT_INTERRUPT, vector);
     return event;
   }
 
-  void interrupt_wait(event::ptr_t event, int timeout=-1)
-  {
+  void interrupt_wait(event::ptr_t event, int timeout = -1) {
     struct pollfd pfd;
     pfd.events = POLLIN;
     pfd.fd = event->os_object();
     auto ret = poll(&pfd, 1, timeout);
 
-    if (ret < 0)
-      throw std::runtime_error(strerror(errno));
-    if (ret == 0)
-      throw std::runtime_error("timeout error");
+    if (ret < 0) throw std::runtime_error(strerror(errno));
+    if (ret == 0) throw std::runtime_error("timeout error");
   }
 
-  void compare(shared_buffer::ptr_t b1,
-               shared_buffer::ptr_t b2, uint32_t count = 0)
-  {
-      if (b1->compare(b2, count ? count : b1->size())) {
-        throw std::runtime_error("buffers mismatch");
-      }
+  void compare(shared_buffer::ptr_t b1, shared_buffer::ptr_t b2,
+               uint32_t count = 0) {
+    if (b1->compare(b2, count ? count : b1->size())) {
+      throw std::runtime_error("buffers mismatch");
+    }
   }
 
-  template<class T>
-  T read_register()
-  {
+  template <class T>
+  T read_register() {
     return *reinterpret_cast<T*>(handle_->mmio_ptr(T::offset));
   }
 
-  template<class T>
-  volatile T* register_ptr(uint32_t offset)
-  {
+  template <class T>
+  volatile T* register_ptr(uint32_t offset) {
     return reinterpret_cast<volatile T*>(handle_->mmio_ptr(offset));
   }
 
-  template<class T>
-  void write_register(uint32_t offset, T* reg)
-  {
+  template <class T>
+  void write_register(uint32_t offset, T* reg) {
     *reinterpret_cast<T*>(handle_->mmio_ptr(offset)) = *reg;
   }
 
-public:
+ public:
   uint32_t count_;
   uint32_t he_modes_;
   uint32_t he_req_cls_len_;
@@ -560,30 +525,20 @@ public:
 
   uint32_t get_offset(uint32_t base, uint32_t i) const {
     auto limit = limits_.find(base);
-    auto offset = base + sizeof(uint64_t)*i;
-    if (limit != limits_.end() &&
-        offset > limit->second - sizeof(uint64_t)) {
+    auto offset = base + sizeof(uint64_t) * i;
+    if (limit != limits_.end() && offset > limit->second - sizeof(uint64_t)) {
       throw std::out_of_range("offset out range in csr space");
     }
     return offset;
   }
-  
-  token::ptr_t get_token()
-  {
-    return handle_->get_token();
-  }
 
-  token::ptr_t get_token_device()
-  {
-    return handle_device_->get_token();
-  }
+  token::ptr_t get_token() { return handle_->get_token(); }
 
-  bool option_passed(std::string option_str)
-  {
-      if (app_.count(option_str) == 0)
-            return false;
-      return true;
+  token::ptr_t get_token_device() { return handle_device_->get_token(); }
+
+  bool option_passed(std::string option_str) {
+    if (app_.count(option_str) == 0) return false;
+    return true;
   }
 };
-} // end of namespace host_exerciser
-
+}  // end of namespace host_exerciser

--- a/samples/host_exerciser/host_exerciser.h
+++ b/samples/host_exerciser/host_exerciser.h
@@ -44,6 +44,7 @@ static const uint64_t LOG2_CL = 6;
 static const size_t LPBK1_DSM_SIZE = 2 * KB;
 static const size_t LPBK1_BUFFER_SIZE = 64 * KB;
 static const size_t LPBK1_BUFFER_ALLOCATION_SIZE = 64 * KB;
+static const size_t MAX_NUM_MEM_CHANNELS = 8; // The maximum number of assumed memory channels created by the dfl-emif driver. 
 
 // Host execiser CSR Offset
 enum {
@@ -570,6 +571,11 @@ public:
   token::ptr_t get_token()
   {
     return handle_->get_token();
+  }
+
+  token::ptr_t get_token_device()
+  {
+    return handle_device_->get_token();
   }
 
   bool option_passed(std::string option_str)

--- a/samples/host_exerciser/host_exerciser.h
+++ b/samples/host_exerciser/host_exerciser.h
@@ -44,9 +44,7 @@ static const uint64_t LOG2_CL = 6;
 static const size_t LPBK1_DSM_SIZE = 2 * KB;
 static const size_t LPBK1_BUFFER_SIZE = 64 * KB;
 static const size_t LPBK1_BUFFER_ALLOCATION_SIZE = 64 * KB;
-static const size_t MAX_NUM_MEM_CHANNELS =
-    8;  // The maximum number of assumed memory channels created by the dfl-emif
-        // driver.
+static const size_t MAX_NUM_MEM_CHANNELS = 8; // The maximum number of assumed memory channels created by the dfl-emif driver. 
 
 // Host execiser CSR Offset
 enum {
@@ -75,7 +73,7 @@ enum {
   HE_INFO0 = 0x0180,
 };
 
-// configures test mode
+//configures test mode
 typedef enum {
   HOST_EXEMODE_LPBK1 = 0x0,
   HOST_EXEMODE_READ = 0x1,
@@ -83,7 +81,7 @@ typedef enum {
   HOST_EXEMODE_TRPUT = 0x3,
 } host_exe_mode;
 
-// request cache line
+//request cache line
 typedef enum {
   HOSTEXE_CLS_1 = 0x0,
   HOSTEXE_CLS_2 = 0x1,
@@ -92,7 +90,7 @@ typedef enum {
   HOSTEXE_CLS_16 = 0x4,
 } hostexe_req_len;
 
-// configures atomic transactions
+//configures atomic transactions
 typedef enum {
   // Bit 0 enables atomic function mode
   // Bit 1 selects 4 byte or 8 byte requests
@@ -106,7 +104,7 @@ typedef enum {
   HOSTEXE_ATOMIC_CAS_8 = 0xb,
 } hostexe_atomic_func;
 
-// configures data mover vs. power user encoding of requests
+//configures data mover vs. power user encoding of requests
 typedef enum {
   HOSTEXE_ENCODING_DEFAULT = 0x0,  // Use the RTL PU_MEM_REQ parameter
   HOSTEXE_ENCODING_DM = 0x1,       // Only data mover
@@ -114,29 +112,35 @@ typedef enum {
   HOSTEXE_ENCODING_RANDOM = 0x3,   // Both DM and PU in the same stream
 } hostexe_encoding;
 
-// he test type
+//he test type
 typedef enum {
   HOSTEXE_TEST_ROLLOVER = 0x0,
   HOSTEXE_TEST_TERMINATION = 0x1,
 } hostexe_test_mode;
 
+
 // DFH Header
-union he_dfh {
-  enum { offset = HE_DFH };
+union he_dfh  {
+  enum {
+    offset = HE_DFH
+  };
   uint64_t value;
   struct {
     uint16_t CcipVersionNumber : 12;
-    uint8_t AfuMajVersion : 4;
+    uint8_t  AfuMajVersion : 4;
     uint32_t NextDfhOffset : 24;
-    uint8_t EOL : 1;
+    uint8_t  EOL : 1;
     uint32_t Reserved : 19;
-    uint8_t FeatureType : 4;
+    uint8_t  FeatureType : 4;
   };
 };
 
+
 // DSM BASEL
 union he_dsm_basel {
-  enum { offset = HE_DSM_BASEL };
+  enum {
+    offset = HE_DSM_BASEL
+  };
   uint32_t value;
   struct {
     uint32_t DsmBaseL : 32;
@@ -145,7 +149,9 @@ union he_dsm_basel {
 
 // DSM BASEH
 union he_dsm_baseh {
-  enum { offset = HE_DSM_BASEH };
+  enum {
+    offset = HE_DSM_BASEH
+  };
   uint32_t value;
   struct {
     uint32_t DsmBaseH : 32;
@@ -154,7 +160,9 @@ union he_dsm_baseh {
 
 // NUM_LINES
 union he_num_lines {
-  enum { offset = HE_NUM_LINES };
+  enum {
+    offset = HE_NUM_LINES
+  };
   uint32_t value;
   struct {
     uint32_t NumCacheLines : 32;
@@ -162,9 +170,12 @@ union he_num_lines {
   };
 };
 
+
 // CSR CTL
-union he_ctl {
-  enum { offset = HE_CTL };
+union he_ctl{
+  enum {
+    offset = HE_CTL
+  };
   uint32_t value;
   struct {
     uint32_t ResetL : 1;
@@ -174,9 +185,12 @@ union he_ctl {
   };
 };
 
+
 // CSR CFG
 union he_cfg {
-  enum { offset = HE_CFG };
+  enum {
+    offset = HE_CFG
+  };
   uint64_t value;
   struct {
     uint64_t DelayEn : 1;
@@ -197,7 +211,9 @@ union he_cfg {
 
 // CSR INACT THRESH
 union he_inact_thresh {
-  enum { offset = HE_INACT_THRESH };
+  enum {
+    offset = HE_INACT_THRESH
+  };
   uint32_t value;
   struct {
     uint32_t InactivtyThreshold : 32;
@@ -206,7 +222,9 @@ union he_inact_thresh {
 
 // INTERRUPT0
 union he_interrupt0 {
-  enum { offset = HE_INTERRUPT0 };
+  enum {
+    offset = HE_INTERRUPT0
+  };
   uint32_t value;
   struct {
     uint32_t apci_id : 16;
@@ -216,7 +234,9 @@ union he_interrupt0 {
 
 // SWTEST MSG
 union he_swtest_msg {
-  enum { offset = HE_SWTEST_MSG };
+  enum {
+    offset = HE_SWTEST_MSG
+  };
   uint64_t value;
   struct {
     uint64_t swtest_msg : 64;
@@ -225,7 +245,9 @@ union he_swtest_msg {
 
 // STATUS0
 union he_status0 {
-  enum { offset = HE_STATUS0 };
+  enum {
+    offset = HE_STATUS0
+  };
   uint64_t value;
   struct {
     uint64_t numWrites : 32;
@@ -235,7 +257,9 @@ union he_status0 {
 
 // STATUS1
 union he_status1 {
-  enum { offset = HE_STATUS1 };
+  enum {
+    offset = HE_STATUS1
+  };
   uint64_t value;
   struct {
     uint64_t numPendWrites : 16;
@@ -245,9 +269,12 @@ union he_status1 {
   };
 };
 
+
 // ERROR
 union he_error {
-  enum { offset = HE_ERROR };
+  enum {
+    offset = HE_ERROR
+  };
   uint64_t value;
   struct {
     uint64_t error : 32;
@@ -257,7 +284,9 @@ union he_error {
 
 // STRIDE
 union he_stride {
-  enum { offset = HE_STRIDE };
+  enum {
+    offset = HE_STRIDE
+  };
   uint32_t value;
   struct {
     uint32_t Stride : 32;
@@ -266,33 +295,35 @@ union he_stride {
 
 // HE DSM status
 struct he_dsm_status {
-  uint64_t test_completed : 1;
-  uint64_t dsm_number : 15;
-  uint64_t res1 : 16;
-  uint64_t err_vector : 32;
-  uint64_t num_ticks : 40;
-  uint64_t res2 : 8;
-  uint64_t num_reads_h : 8;
-  uint64_t num_writes_h : 8;
-  uint64_t num_reads_l : 32;
-  uint64_t num_writes_l : 32;
-  uint64_t penalty_start : 16;
-  uint64_t res3 : 16;
-  uint64_t penalty_end : 8;
-  uint64_t res4 : 24;
-  uint64_t ab_error_info : 32;
-  uint32_t res5[7];
+	uint64_t test_completed : 1;
+	uint64_t dsm_number : 15;
+	uint64_t res1 : 16;
+	uint64_t err_vector : 32;
+	uint64_t num_ticks : 40;
+	uint64_t res2 : 8;
+	uint64_t num_reads_h : 8;
+	uint64_t num_writes_h : 8;
+	uint64_t num_reads_l : 32;
+	uint64_t num_writes_l : 32;
+	uint64_t penalty_start : 16;
+	uint64_t res3 : 16;
+	uint64_t penalty_end : 8;
+	uint64_t res4 : 24;
+	uint64_t ab_error_info : 32;
+	uint32_t res5[7];
 };
 
 const std::map<std::string, uint32_t> he_modes = {
-    {"lpbk", HOST_EXEMODE_LPBK1},
-    {"read", HOST_EXEMODE_READ},
-    {"write", HOST_EXEMODE_WRITE},
-    {"trput", HOST_EXEMODE_TRPUT},
+  { "lpbk", HOST_EXEMODE_LPBK1},
+  { "read", HOST_EXEMODE_READ},
+  { "write", HOST_EXEMODE_WRITE},
+  { "trput", HOST_EXEMODE_TRPUT},
 };
 
-struct MapKeyComparator {
-  bool operator()(const std::string& a, const std::string& b) const {
+struct MapKeyComparator
+{
+  bool operator()( const std::string& a, const std::string& b ) const
+  {
     if (a.length() != b.length())
       return (a.length() < b.length());
     else
@@ -301,127 +332,119 @@ struct MapKeyComparator {
 };
 
 const std::map<std::string, uint32_t, MapKeyComparator> he_req_cls_len = {
-    {"cl_1", HOSTEXE_CLS_1}, {"cl_2", HOSTEXE_CLS_2},   {"cl_4", HOSTEXE_CLS_4},
-    {"cl_8", HOSTEXE_CLS_8}, {"cl_16", HOSTEXE_CLS_16},
+  { "cl_1", HOSTEXE_CLS_1},
+  { "cl_2", HOSTEXE_CLS_2},
+  { "cl_4", HOSTEXE_CLS_4},
+  { "cl_8", HOSTEXE_CLS_8},
+  { "cl_16", HOSTEXE_CLS_16},
 };
 
 const std::map<std::string, uint32_t> he_req_atomic_func = {
-    {"off", HOSTEXE_ATOMIC_OFF},       {"fadd_4", HOSTEXE_ATOMIC_FADD_4},
-    {"fadd_8", HOSTEXE_ATOMIC_FADD_8}, {"swap_4", HOSTEXE_ATOMIC_SWAP_4},
-    {"swap_8", HOSTEXE_ATOMIC_SWAP_8}, {"cas_4", HOSTEXE_ATOMIC_CAS_4},
-    {"cas_8", HOSTEXE_ATOMIC_CAS_8},
+  { "off", HOSTEXE_ATOMIC_OFF},
+  { "fadd_4", HOSTEXE_ATOMIC_FADD_4},
+  { "fadd_8", HOSTEXE_ATOMIC_FADD_8},
+  { "swap_4", HOSTEXE_ATOMIC_SWAP_4},
+  { "swap_8", HOSTEXE_ATOMIC_SWAP_8},
+  { "cas_4", HOSTEXE_ATOMIC_CAS_4},
+  { "cas_8", HOSTEXE_ATOMIC_CAS_8},
 };
 
 const std::map<std::string, uint32_t> he_req_encoding = {
-    {"default", HOSTEXE_ENCODING_DEFAULT},
-    {"dm", HOSTEXE_ENCODING_DM},
-    {"pu", HOSTEXE_ENCODING_PU},
-    {"random", HOSTEXE_ENCODING_RANDOM},
+  { "default", HOSTEXE_ENCODING_DEFAULT},
+  { "dm", HOSTEXE_ENCODING_DM},
+  { "pu", HOSTEXE_ENCODING_PU},
+  { "random", HOSTEXE_ENCODING_RANDOM},
 };
 
 const std::map<std::string, uint32_t> he_test_mode = {
-    {"test_rollover", HOSTEXE_TEST_ROLLOVER},
-    {"test_termination", HOSTEXE_TEST_TERMINATION}};
+  { "test_rollover", HOSTEXE_TEST_ROLLOVER},
+  { "test_termination", HOSTEXE_TEST_TERMINATION}
+};
+
 
 using test_afu = opae::afu_test::afu;
 using test_command = opae::afu_test::command;
 
 // Inerleave help
-const char* interleave_help =
-    R"desc(Interleave requests pattern to use in throughput mode {0, 1, 2}
+const char *interleave_help = R"desc(Interleave requests pattern to use in throughput mode {0, 1, 2}
 indicating one of the following series of read/write requests:
 0: rd-wr-rd-wr
 1: rd-rd-wr-wr
 2: rd-rd-rd-rd-wr-wr-wr-wr)desc";
 
+
 class host_exerciser : public test_afu {
- public:
-  host_exerciser()
-      : test_afu("host_exerciser", nullptr, "warning"),
-        count_(1),
-        he_interleave_(0),
-        he_interrupt_(0xffff) {
+public:
+    host_exerciser()
+  : test_afu("host_exerciser", nullptr, "warning")
+  , count_(1)
+  , he_interleave_(0)
+  , he_interrupt_(0xffff)
+  {
     // Mode
-    app_.add_option("-m,--mode", he_modes_,
-                    "host exerciser mode {lpbk,read, write, trput}")
-        ->transform(CLI::CheckedTransformer(he_modes))
-        ->default_val("lpbk");
+    app_.add_option("-m,--mode", he_modes_, "host exerciser mode {lpbk,read, write, trput}")
+      ->transform(CLI::CheckedTransformer(he_modes))->default_val("lpbk");
 
     // Cache line
-    app_.add_option("--cls", he_req_cls_len_,
-                    "number of CLs per request{cl_1, cl_2, cl_4, cl_8, cl_16}")
-        ->transform(CLI::CheckedTransformer(he_req_cls_len))
-        ->default_val("cl_1");
+    app_.add_option("--cls", he_req_cls_len_, "number of CLs per request{cl_1, cl_2, cl_4, cl_8, cl_16}")
+       ->transform(CLI::CheckedTransformer(he_req_cls_len))->default_val("cl_1");
 
     // Configures test rollover or test termination
-    app_.add_option("--continuousmode", he_continuousmode_,
-                    "test rollover or test termination")
-        ->default_val("false");
+    app_.add_option("--continuousmode", he_continuousmode_, "test rollover or test termination")->default_val("false");
 
     // Atomic function
-    app_.add_option(
-            "--atomic", he_req_atomic_func_,
-            "atomic requests (only permitted in combination with lpbk/cl_1)")
-        ->transform(CLI::CheckedTransformer(he_req_atomic_func))
-        ->default_val("off");
+    app_.add_option("--atomic", he_req_atomic_func_, "atomic requests (only permitted in combination with lpbk/cl_1)")
+      ->transform(CLI::CheckedTransformer(he_req_atomic_func))->default_val("off");
 
     // Encoding
-    app_.add_option("--encoding", he_req_encoding_,
-                    "data mover or power user encoding -- random interleaves "
-                    "both in the same stream")
-        ->transform(CLI::CheckedTransformer(he_req_encoding))
-        ->default_val("default");
+    app_.add_option("--encoding", he_req_encoding_, "data mover or power user encoding -- random interleaves both in the same stream")
+      ->transform(CLI::CheckedTransformer(he_req_encoding))->default_val("default");
 
     // Delay
-    app_.add_option("-d,--delay", he_delay_,
-                    "Enables random delay insertion between requests")
-        ->default_val("false");
+    app_.add_option("-d,--delay", he_delay_, "Enables random delay insertion between requests")->default_val("false");
 
     // Configure interleave requests in Throughput mode
-    app_.add_option("--interleave", he_interleave_, interleave_help)
-        ->transform(CLI::Range(0, 2));
+    app_.add_option("--interleave", he_interleave_, interleave_help)->transform(CLI::Range(0, 2));
 
     // The Interrupt Vector Number for the device
     app_.add_option("--interrupt", he_interrupt_,
-                    "The Interrupt Vector Number for the device")
+        "The Interrupt Vector Number for the device")
         ->transform(CLI::Range(0, 4095));
 
-    // Continuous mode time
+     // Continuous mode time
     app_.add_option("--contmodetime", he_contmodetime_,
-                    "Continuous mode time in seconds")
-        ->default_val("1");
+        "Continuous mode time in seconds")->default_val("1");
 
     // Test all
-    app_.add_option("--testall", he_test_all_, "Run all tests")
-        ->default_val("false");
+    app_.add_option("--testall", he_test_all_, "Run all tests")->default_val("false");
 
     app_.add_option("--clock-mhz", he_clock_mhz_,
-                    "Clock frequency (MHz) -- when zero, read the frequency "
-                    "from the AFU")
-        ->default_val("0");
-  }
+        "Clock frequency (MHz) -- when zero, read the frequency from the AFU")->default_val("0");
+   }
 
-  virtual int run(CLI::App* app, test_command::ptr_t test) override {
+  virtual int run(CLI::App *app, test_command::ptr_t test) override
+  {
     int res = exit_codes::not_run;
 
     logger_->set_pattern("    %v");
-    // Info prints details of an individual run. Turn it on if doing only one
-    // test and the user hasn't changed level from the default.
+    // Info prints details of an individual run. Turn it on if doing only one test
+    // and the user hasn't changed level from the default.
     if ((log_level_.compare("warning") == 0) && !he_test_all_)
-      logger_->set_level(spdlog::level::info);
+        logger_->set_level(spdlog::level::info);
 
     logger_->info("starting test run, count of {0:d}", count_);
     uint32_t count = 0;
     try {
       while (count < count_) {
-        logger_->debug("starting iteration: {0:d}", count + 1);
-
+        logger_->debug("starting iteration: {0:d}", count+1);
+     
         res = test_afu::run(app, test);
         count++;
         logger_->debug("end iteration: {0:d}", count);
-        if (res) break;
+        if (res)
+          break;
       }
-    } catch (std::exception& ex) {
+    } catch(std::exception &ex) {
       logger_->error(ex.what());
       res = exit_codes::exception;
     }
@@ -432,82 +455,94 @@ class host_exerciser : public test_afu {
     return res;
   }
 
-  template <typename T>
+  template<typename T>
   inline T read(uint32_t offset) const {
     return *reinterpret_cast<T*>(handle_->mmio_ptr(offset));
   }
 
-  template <typename T>
+  template<typename T>
   inline void write(uint32_t offset, T value) const {
     *reinterpret_cast<T*>(handle_->mmio_ptr(offset)) = value;
   }
 
-  template <typename T>
+  template<typename T>
   T read(uint32_t offset, uint32_t i) const {
     return read<T>(get_offset(offset, i));
   }
 
-  template <typename T>
+  template<typename T>
   void write(uint32_t offset, uint32_t i, T value) const {
     write<T>(get_offset(offset, i), value);
   }
 
-  shared_buffer::ptr_t allocate(size_t size) {
+  shared_buffer::ptr_t allocate(size_t size)
+  {
     return shared_buffer::allocate(handle_, size);
   }
 
-  void fill(shared_buffer::ptr_t buffer) {
+  void fill(shared_buffer::ptr_t buffer)
+  {
     std::random_device rd;
     std::mt19937 mt(rd());
     std::uniform_int_distribution<uint32_t> dist(1, -1);
     auto sz = sizeof(uint32_t);
-    for (uint32_t i = 0; i < buffer->size(); i += sz) {
+    for (uint32_t i = 0; i < buffer->size(); i+=sz){
       buffer->write<uint32_t>(dist(mt), i);
     }
+
   }
 
-  void fill(shared_buffer::ptr_t buffer, uint32_t value) {
+  void fill(shared_buffer::ptr_t buffer, uint32_t value)
+  {
     buffer->fill(value);
   }
 
-  event::ptr_t register_interrupt(uint32_t vector) {
+  event::ptr_t register_interrupt(uint32_t vector)
+  {
     auto event = event::register_event(handle_, FPGA_EVENT_INTERRUPT, vector);
     return event;
   }
 
-  void interrupt_wait(event::ptr_t event, int timeout = -1) {
+  void interrupt_wait(event::ptr_t event, int timeout=-1)
+  {
     struct pollfd pfd;
     pfd.events = POLLIN;
     pfd.fd = event->os_object();
     auto ret = poll(&pfd, 1, timeout);
 
-    if (ret < 0) throw std::runtime_error(strerror(errno));
-    if (ret == 0) throw std::runtime_error("timeout error");
+    if (ret < 0)
+      throw std::runtime_error(strerror(errno));
+    if (ret == 0)
+      throw std::runtime_error("timeout error");
   }
 
-  void compare(shared_buffer::ptr_t b1, shared_buffer::ptr_t b2,
-               uint32_t count = 0) {
-    if (b1->compare(b2, count ? count : b1->size())) {
-      throw std::runtime_error("buffers mismatch");
-    }
+  void compare(shared_buffer::ptr_t b1,
+               shared_buffer::ptr_t b2, uint32_t count = 0)
+  {
+      if (b1->compare(b2, count ? count : b1->size())) {
+        throw std::runtime_error("buffers mismatch");
+      }
   }
 
-  template <class T>
-  T read_register() {
+  template<class T>
+  T read_register()
+  {
     return *reinterpret_cast<T*>(handle_->mmio_ptr(T::offset));
   }
 
-  template <class T>
-  volatile T* register_ptr(uint32_t offset) {
+  template<class T>
+  volatile T* register_ptr(uint32_t offset)
+  {
     return reinterpret_cast<volatile T*>(handle_->mmio_ptr(offset));
   }
 
-  template <class T>
-  void write_register(uint32_t offset, T* reg) {
+  template<class T>
+  void write_register(uint32_t offset, T* reg)
+  {
     *reinterpret_cast<T*>(handle_->mmio_ptr(offset)) = *reg;
   }
 
- public:
+public:
   uint32_t count_;
   uint32_t he_modes_;
   uint32_t he_req_cls_len_;
@@ -525,20 +560,30 @@ class host_exerciser : public test_afu {
 
   uint32_t get_offset(uint32_t base, uint32_t i) const {
     auto limit = limits_.find(base);
-    auto offset = base + sizeof(uint64_t) * i;
-    if (limit != limits_.end() && offset > limit->second - sizeof(uint64_t)) {
+    auto offset = base + sizeof(uint64_t)*i;
+    if (limit != limits_.end() &&
+        offset > limit->second - sizeof(uint64_t)) {
       throw std::out_of_range("offset out range in csr space");
     }
     return offset;
   }
+  
+  token::ptr_t get_token()
+  {
+    return handle_->get_token();
+  }
 
-  token::ptr_t get_token() { return handle_->get_token(); }
+  token::ptr_t get_token_device()
+  {
+    return handle_device_->get_token();
+  }
 
-  token::ptr_t get_token_device() { return handle_device_->get_token(); }
-
-  bool option_passed(std::string option_str) {
-    if (app_.count(option_str) == 0) return false;
-    return true;
+  bool option_passed(std::string option_str)
+  {
+      if (app_.count(option_str) == 0)
+            return false;
+      return true;
   }
 };
-}  // end of namespace host_exerciser
+} // end of namespace host_exerciser
+

--- a/samples/host_exerciser/host_exerciser_cmd.h
+++ b/samples/host_exerciser/host_exerciser_cmd.h
@@ -27,10 +27,10 @@
 
 #include <unistd.h>
 
-#include <opae/cxx/core.h>
-#include <opae/types_enum.h>
 #include "afu_test.h"
 #include "host_exerciser.h"
+#include <opae/types_enum.h>
+#include <opae/cxx/core.h>
 
 using test_afu = opae::afu_test::afu;
 using opae::fpga::types::shared_buffer;
@@ -41,829 +41,831 @@ namespace fpga = opae::fpga::types;
 volatile bool g_he_exit = false;
 
 // host exerciser signal handler
-void he_sig_handler(int) {
-  g_he_exit = true;
-  printf("HE signal handler exit app \n");
+void he_sig_handler(int)
+{
+    g_he_exit = true;
+    printf("HE signal handler exit app \n");
 }
 
 namespace host_exerciser {
 
-class host_exerciser_cmd : public test_command {
- public:
-  host_exerciser_cmd() : host_exe_(NULL) {
-    he_lpbk_cfg_.value = 0;
-    he_lpbk_ctl_.value = 0;
-    he_lpbk_max_reqlen_ = HOSTEXE_CLS_8;
-    he_lpbk_api_ver_ = 0;
-    he_lpbk_atomics_supported_ = false;
-    is_ase_sim_ = false;
-  }
-  virtual ~host_exerciser_cmd() {}
 
-  void host_exerciser_status() {
-    he_status0 he_status0;
-    he_status1 he_status1;
+class host_exerciser_cmd : public test_command
+{
+public:
+    host_exerciser_cmd()
+        :host_exe_(NULL) {
+          he_lpbk_cfg_.value = 0;
+          he_lpbk_ctl_.value = 0;
+          he_lpbk_max_reqlen_ = HOSTEXE_CLS_8;
+          he_lpbk_api_ver_ = 0;
+          he_lpbk_atomics_supported_ = false;
+          is_ase_sim_ = false;
+    }
+    virtual ~host_exerciser_cmd() {}
 
-    he_status0.value = host_exe_->read64(HE_STATUS0);
-    he_status1.value = host_exe_->read64(HE_STATUS1);
+    void host_exerciser_status()
+    {
+        he_status0 he_status0;
+        he_status1 he_status1;
 
-    uint64_t tmp;
+        he_status0.value = host_exe_->read64(HE_STATUS0);
+        he_status1.value = host_exe_->read64(HE_STATUS1);
 
-    tmp = he_status0.numReads;
-    host_exe_->logger_->info("Host Exerciser numReads: {0}", tmp);
-    tmp = he_status0.numWrites;
-    host_exe_->logger_->info("Host Exerciser numWrites: {0}", tmp);
+        uint64_t tmp;
 
-    tmp = he_status1.numPendReads;
-    host_exe_->logger_->info("Host Exerciser numPendReads: {0}", tmp);
-    tmp = he_status1.numPendWrites;
-    host_exe_->logger_->info("Host Exerciser numPendWrites: {0}", tmp);
+        tmp = he_status0.numReads;
+        host_exe_->logger_->info("Host Exerciser numReads: {0}", tmp);
+        tmp = he_status0.numWrites;
+        host_exe_->logger_->info("Host Exerciser numWrites: {0}", tmp);
 
-    tmp = he_status1.numPendEmifReads;
-    host_exe_->logger_->info("Host Exerciser numPendEmifReads: {0}", tmp);
-    tmp = he_status1.numPendEmifWrites;
-    host_exe_->logger_->info("Host Exerciser numPendEmifWrites: {0}", tmp);
-  }
+        tmp = he_status1.numPendReads;
+        host_exe_->logger_->info("Host Exerciser numPendReads: {0}", tmp);
+        tmp = he_status1.numPendWrites;
+        host_exe_->logger_->info("Host Exerciser numPendWrites: {0}", tmp);
 
-  void host_exerciser_errors() {
-    he_error he_error;
-
-    if (host_exe_ == NULL) return;
-
-    he_error.value = host_exe_->read64(HE_ERROR);
-
-    std::cout << "Host Exerciser Error:" << he_error.error << std::endl;
-  }
-
-  uint64_t host_exerciser_swtestmsg() {
-    uint64_t swtest_msg;
-
-    if (host_exe_ == NULL) return 0;
-
-    swtest_msg = host_exe_->read64(HE_SWTEST_MSG);
-    if (swtest_msg) {
-      std::cout << "Host Exerciser swtest msg:" << swtest_msg << std::endl;
+        tmp = he_status1.numPendEmifReads;
+        host_exe_->logger_->info("Host Exerciser numPendEmifReads: {0}", tmp);
+        tmp = he_status1.numPendEmifWrites;
+        host_exe_->logger_->info("Host Exerciser numPendEmifWrites: {0}", tmp);
     }
 
-    return swtest_msg;
-  }
+    void host_exerciser_errors()
+    {
+        he_error he_error;
 
-  inline uint64_t cacheline_aligned_addr(uint64_t num) {
-    return num >> LOG2_CL;
-  }
+        if (host_exe_ == NULL)
+            return;
 
-  // Convert number of transactions to bandwidth (GB/s)
-  double he_num_xfers_to_bw(uint64_t num_lines, uint64_t num_ticks) {
-    return (double)(num_lines * 64) /
-           ((1000.0 / host_exe_->he_clock_mhz_ * num_ticks));
-  }
+        he_error.value = host_exe_->read64(HE_ERROR);
 
-  inline uint64_t dsm_num_ticks(const volatile he_dsm_status *dsm_status) {
-    return dsm_status->num_ticks;
-  }
+        std::cout << "Host Exerciser Error:" << he_error.error << std::endl;
 
-  // Read count has two parts -- the size was increased after the first release
-  inline uint64_t dsm_num_reads(const volatile he_dsm_status *dsm_status) {
-    return (uint64_t(dsm_status->num_reads_h) << 32) | dsm_status->num_reads_l;
-  }
-
-  // Write count has two parts -- the size was increased after the first release
-  inline uint64_t dsm_num_writes(const volatile he_dsm_status *dsm_status) {
-    return (uint64_t(dsm_status->num_writes_h) << 32) |
-           dsm_status->num_writes_l;
-  }
-
-  void he_perf_counters() {
-    volatile he_dsm_status *dsm_status = NULL;
-    volatile uint8_t *status_ptr = dsm_->c_type();
-    uint64_t num_cache_lines = 0;
-    if (!status_ptr) return;
-
-    dsm_status = reinterpret_cast<he_dsm_status *>((uint8_t *)status_ptr);
-    if (!dsm_status) return;
-
-    host_exe_->logger_->info("Host Exerciser Performance Counter:");
-    // calculate number of cache lines in continuous mode
-    if (host_exe_->he_continuousmode_) {
-      if (he_lpbk_cfg_.TestMode == HOST_EXEMODE_READ)
-        num_cache_lines = dsm_num_reads(dsm_status);
-      else if (he_lpbk_cfg_.TestMode == HOST_EXEMODE_WRITE)
-        num_cache_lines = (dsm_num_writes(dsm_status));
-      else
-        num_cache_lines =
-            dsm_num_reads(dsm_status) + dsm_num_writes(dsm_status);
-    } else {
-      num_cache_lines = (LPBK1_BUFFER_SIZE / (1 * CL));
     }
 
-    host_exerciser_status();
+    uint64_t host_exerciser_swtestmsg()
+    {
+        uint64_t swtest_msg;
 
-    uint64_t tmp;
+        if (host_exe_ == NULL)
+            return 0;
 
-    tmp = dsm_num_ticks(dsm_status);
-    host_exe_->logger_->info("Number of clocks: {0}", tmp);
-    tmp = dsm_num_reads(dsm_status);
-    host_exe_->logger_->info("Total number of Reads sent: {0}", tmp);
-    tmp = dsm_num_writes(dsm_status);
-    host_exe_->logger_->info("Total number of Writes sent: {0}", tmp);
+        swtest_msg = host_exe_->read64(HE_SWTEST_MSG);
+        if (swtest_msg) {
+            std::cout << "Host Exerciser swtest msg:" << swtest_msg << std::endl;
+        }
 
-    // print bandwidth
-    if (dsm_num_ticks(dsm_status) > 0) {
-      double perf_data =
-          he_num_xfers_to_bw(num_cache_lines, dsm_num_ticks(dsm_status));
-      host_exe_->logger_->info("Bandwidth: {0:0.3f} GB/s", perf_data);
-    }
-  }
-
-  bool he_interrupt(event::ptr_t ev) {
-    try {
-      host_exe_->interrupt_wait(ev, 10000);
-      if (he_lpbk_cfg_.TestMode == HOST_EXEMODE_LPBK1)
-        host_exe_->compare(source_, destination_);
-    } catch (std::exception &ex) {
-      std::cout << "Exception: " << ex.what() << std::endl;
-      host_exerciser_errors();
-      return false;
-    }
-    return true;
-  }
-
-  bool he_wait_test_completion() {
-    /* Wait for test completion */
-    uint32_t timeout = HELPBK_TEST_TIMEOUT;
-    if (is_ase_sim_) {
-      // Much longer timeout when running HW simulation
-      timeout *= 100;
+        return swtest_msg;
     }
 
-    volatile uint8_t *status_ptr = dsm_->c_type();
+    inline uint64_t cacheline_aligned_addr(uint64_t num) {
+        return num >> LOG2_CL;
+    }
 
-    while (0 == ((*status_ptr) & 0x1)) {
-      usleep(HELPBK_TEST_SLEEP_INVL);
-      if (--timeout == 0) {
-        std::cout << "HE LPBK TIME OUT" << std::endl;
-        host_exerciser_errors();
+    // Convert number of transactions to bandwidth (GB/s)
+    double he_num_xfers_to_bw(uint64_t num_lines, uint64_t num_ticks)
+    {
+        return (double)(num_lines * 64) / ((1000.0 / host_exe_->he_clock_mhz_ * num_ticks));
+    }
+
+    inline uint64_t dsm_num_ticks(const volatile he_dsm_status *dsm_status)
+    {
+        return dsm_status->num_ticks;
+    }
+
+    // Read count has two parts -- the size was increased after the first release
+    inline uint64_t dsm_num_reads(const volatile he_dsm_status *dsm_status)
+    {
+        return (uint64_t(dsm_status->num_reads_h) << 32) | dsm_status->num_reads_l;
+    }
+
+    // Write count has two parts -- the size was increased after the first release
+    inline uint64_t dsm_num_writes(const volatile he_dsm_status *dsm_status)
+    {
+        return (uint64_t(dsm_status->num_writes_h) << 32) | dsm_status->num_writes_l;
+    }
+
+    void he_perf_counters()
+    {
+        volatile he_dsm_status *dsm_status = NULL;
+        volatile uint8_t* status_ptr = dsm_->c_type();
+        uint64_t num_cache_lines = 0;
+        if (!status_ptr)
+           return;
+
+        dsm_status = reinterpret_cast<he_dsm_status *>((uint8_t*)status_ptr);
+        if (!dsm_status)
+            return;
+
+        host_exe_->logger_->info("Host Exerciser Performance Counter:");
+        // calculate number of cache lines in continuous mode
+        if (host_exe_->he_continuousmode_) {
+            if (he_lpbk_cfg_.TestMode == HOST_EXEMODE_READ)
+                num_cache_lines = dsm_num_reads(dsm_status);
+            else if (he_lpbk_cfg_.TestMode == HOST_EXEMODE_WRITE)
+                num_cache_lines = (dsm_num_writes(dsm_status));
+            else
+                num_cache_lines = dsm_num_reads(dsm_status) + dsm_num_writes(dsm_status);
+        } else {
+            num_cache_lines = (LPBK1_BUFFER_SIZE / (1 * CL));
+        }
+
         host_exerciser_status();
-        return false;
-      }
-    }
-    return true;
-  }
 
-  void he_forcetestcmpl() {
-    // Force stop test
-    he_lpbk_ctl_.value = 0;
-    he_lpbk_ctl_.ResetL = 1;
-    he_lpbk_ctl_.ForcedTestCmpl = 1;
-    host_exe_->write32(HE_CTL, he_lpbk_ctl_.value);
+        uint64_t tmp;
 
-    if (!he_wait_test_completion()) sleep(1);
+        tmp = dsm_num_ticks(dsm_status);
+        host_exe_->logger_->info("Number of clocks: {0}", tmp);
+        tmp = dsm_num_reads(dsm_status);
+        host_exe_->logger_->info("Total number of Reads sent: {0}", tmp);
+        tmp = dsm_num_writes(dsm_status);
+        host_exe_->logger_->info("Total number of Writes sent: {0}", tmp);
 
-    he_lpbk_ctl_.value = 0;
-    host_exe_->write32(HE_CTL, he_lpbk_ctl_.value);
-    usleep(1000);
-  }
-
-  void he_init_src_buffer(shared_buffer::ptr_t buffer) {
-    // Fill the source buffer with random values
-    host_exe_->fill(buffer);
-
-    // Compare and swap? If so, seed the source buffers with values will
-    // match. The hardware tests uses the line index as the test.
-    if (he_lpbk_cfg_.AtomicFunc == HOSTEXE_ATOMIC_CAS_4) {
-      for (uint32_t i = 0; i < buffer->size() / CL; i += 3) {
-        buffer->write<uint32_t>(i, i * CL);
-      }
-    }
-    if (he_lpbk_cfg_.AtomicFunc == HOSTEXE_ATOMIC_CAS_8) {
-      for (uint32_t i = 0; i < buffer->size() / CL; i += 3) {
-        buffer->write<uint64_t>(i, i * CL);
-      }
-    }
-
-    // In atomic mode, at most the first 8 bytes of each line will be
-    // updated and copied. In the source buffer, write a function of
-    // the value at the start of each line to the second position so
-    // it can be used as a check later.
-    if (he_lpbk_cfg_.AtomicFunc != HOSTEXE_ATOMIC_OFF) {
-      for (uint32_t i = 0; i < buffer->size() / CL; i += 1) {
-        uint64_t v = buffer->read<uint64_t>(i * CL);
-        buffer->write<uint64_t>(v ^ 0xabababababababab, i * CL + 8);
-      }
-    }
-  }
-
-  void he_dump_buffer(shared_buffer::ptr_t buffer, const char *msg) {
-    std::cout << msg << ":" << std::endl;
-
-    // Dump the first 8 lines of a buffer
-    for (uint64_t i = 0; i < 8; i++) {
-      std::cout << std::hex << " " << std::setfill('0') << std::setw(16)
-                << buffer->read<uint64_t>(i * CL + 8 * 7) << " "
-                << std::setfill('0') << std::setw(16)
-                << buffer->read<uint64_t>(i * CL + 8 * 6) << " "
-                << std::setfill('0') << std::setw(16)
-                << buffer->read<uint64_t>(i * CL + 8 * 5) << " "
-                << std::setfill('0') << std::setw(16)
-                << buffer->read<uint64_t>(i * CL + 8 * 4) << " "
-                << std::setfill('0') << std::setw(16)
-                << buffer->read<uint64_t>(i * CL + 8 * 3) << " "
-                << std::setfill('0') << std::setw(16)
-                << buffer->read<uint64_t>(i * CL + 8 * 2) << " "
-                << std::setfill('0') << std::setw(16)
-                << buffer->read<uint64_t>(i * CL + 8 * 1) << " "
-                << std::setfill('0') << std::setw(16)
-                << buffer->read<uint64_t>(i * CL) << std::dec << std::endl;
-    }
-
-    std::cout << " ..." << std::endl;
-  }
-
-  uint64_t he_compare_buffer() {
-    uint64_t status = host_exerciser_swtestmsg();
-    if (status) {
-      std::cerr << "HE LB CSR error flag is set" << std::endl;
-      return status;
-    }
-
-    // Compare buffer contents only loopback test mode
-    if (he_lpbk_cfg_.TestMode != HOST_EXEMODE_LPBK1) return 0;
-
-    // Normal (non-atomic) is a simple comparison
-    if (he_lpbk_cfg_.AtomicFunc == HOSTEXE_ATOMIC_OFF) {
-      return (source_->compare(destination_, source_->size()));
-    }
-
-    // Atomic mode is a far more complicated comparison. The source buffer
-    // is modified and some of the original state is copied to the destination.
-    bool size_is_4 = ((he_lpbk_cfg_.AtomicFunc & 2) == 0);
-    bool is_fetch_add = (he_lpbk_cfg_.AtomicFunc & 0xc) == 0;
-    bool is_swap = (he_lpbk_cfg_.AtomicFunc & 0xc) == 4;
-    bool is_cas = (he_lpbk_cfg_.AtomicFunc & 0xc) == 8;
-
-    // Ignore the last entry to work around an off by one copy error
-    for (uint64_t i = 0; i < source_->size() / CL; i += 1) {
-      // In source_, the first entry in every line is the atomically modified
-      // value. The second entry holds the original value, hashed with a
-      // constant so it isn't a simple repetition.
-      uint64_t src_a = source_->read<uint64_t>(i * CL);
-      // Read the original value and reverse the hash.
-      uint64_t src_b = source_->read<uint64_t>(i * CL + 8) ^ 0xabababababababab;
-      uint64_t upd_a = 0;
-
-      // Compute expected value
-      if (is_fetch_add) {
-        // Hardware added the line index (i) to each line, either preserving
-        // the high 4 bytes or modifying all 8 bytes.
-        if (size_is_4)
-          upd_a = (src_b & 0xffffffff00000000) | ((src_b + i) & 0xffffffff);
-        else
-          upd_a = src_b + i;
-      }
-      if (is_swap) {
-        // Hardware swapped the line index (i) into each line
-        if (size_is_4)
-          upd_a = (src_b & 0xffffffff00000000) | (i & 0xffffffff);
-        else
-          upd_a = i;
-      }
-      if (is_cas) {
-        // Hardware swapped the bit inverse of line index (i) in each line when
-        // the original value is the line index.
-        if (size_is_4)
-          upd_a = ((src_b & 0xffffffff) == i)
-                      ? (src_b & 0xffffffff00000000) | (~i & 0xffffffff)
-                      : src_b;
-        else
-          upd_a = (src_b == i) ? ~i : src_b;
-      }
-
-      if (upd_a != src_a) {
-        std::cerr << "Atomic update error" << std::endl;
-        return 1;
-      }
-
-      // The destination is comparatively easy. For all functions it is
-      // simply the original source value.
-      uint64_t dst_a = destination_->read<uint64_t>(i * CL);
-      if (size_is_4) {
-        src_b &= 0xffffffff;
-        dst_a &= 0xffffffff;
-      }
-
-      if (dst_a != src_b) {
-        std::cerr << "Atomic read error or write error" << std::endl;
-        return 1;
-      }
-    }
-
-    return 0;
-  }
-
-  bool he_continuousmode() {
-    uint32_t count = 0;
-    if (host_exe_->he_continuousmode_ && host_exe_->he_contmodetime_ > 0) {
-      host_exe_->logger_->debug("continuous mode time: {0} seconds",
-                                host_exe_->he_contmodetime_);
-      host_exe_->logger_->debug("Ctrl+C  to stop continuous mode");
-
-      while (!g_he_exit) {
-        sleep(1);
-        count++;
-        if (count > host_exe_->he_contmodetime_) break;
-      }
-      he_forcetestcmpl();
-      he_perf_counters();
-    }
-    return true;
-  }
-
-  inline void set_cfg_reqlen(hostexe_req_len req_len) {
-    // Legal request lengths have grown over time, leading to the field being
-    // split in the configuration register.
-    he_lpbk_cfg_.ReqLen_High = req_len >> 2;
-    he_lpbk_cfg_.ReqLen = req_len & 3;
-  }
-
-  inline void set_cfg_reqlen(uint32_t req_len) {
-    set_cfg_reqlen(static_cast<hostexe_req_len>(req_len));
-  }
-
-  inline hostexe_req_len get_cfg_reqlen() {
-    return static_cast<hostexe_req_len>((he_lpbk_cfg_.ReqLen_High << 2) |
-                                        he_lpbk_cfg_.ReqLen);
-  }
-
-  int parse_input_options() {
-    if (!host_exe_) return -1;
-
-    // ASE simulation?
-    auto afu_props = fpga::properties::get(token_);
-    uint32_t vendor_id = afu_props->vendor_id;
-    uint32_t device_id = afu_props->device_id;
-    is_ase_sim_ = (vendor_id == 0x8086) && (device_id == 0xa5e);
-    if (is_ase_sim_) {
-      std::cout << "Simulation: ASE mode" << std::endl;
-    }
-
-    // Host Exerciser Mode
-    he_lpbk_cfg_.TestMode = host_exe_->he_modes_;
-
-    // Host Exerciser Read
-    if (host_exe_->he_req_cls_len_ > he_lpbk_max_reqlen_) {
-      std::cerr << "Request length " << host_exe_->he_req_cls_len_
-                << " is not supported by this platform." << std::endl;
-      return -1;
-    }
-    set_cfg_reqlen(host_exe_->he_req_cls_len_);
-
-    // Host Exerciser  lpbk delay
-    if (host_exe_->he_delay_) he_lpbk_cfg_.DelayEn = 1;
-
-    // test rollover or test termination
-    if (host_exe_->he_continuousmode_) he_lpbk_cfg_.Continuous = 1;
-
-    // Set interleave in Throughput
-    if (he_lpbk_cfg_.TestMode == HOST_EXEMODE_TRPUT) {
-      he_lpbk_cfg_.TputInterleave = host_exe_->he_interleave_;
-    }
-
-    // Set Interrupt test mode
-    if (host_exe_->option_passed("--interrupt")) {
-      if (host_exe_->he_interrupt_ < afu_props->num_interrupts) {
-        he_lpbk_cfg_.IntrTestMode = 1;
-      } else {
-        std::cerr << "Invalid Input interrupts vector number:"
-                  << host_exe_->he_interrupt_ << std::endl;
-        std::cout << "Please enter Interrupts vector range 0 to "
-                  << afu_props->num_interrupts - 1 << std::endl;
-        return -1;
-      }
-    }
-
-    // Atomic functions
-    he_lpbk_cfg_.AtomicFunc = host_exe_->he_req_atomic_func_;
-    if (he_lpbk_cfg_.AtomicFunc != HOSTEXE_ATOMIC_OFF) {
-      if (!he_lpbk_atomics_supported_) {
-        std::cerr << "The platform does not support atomic functions"
-                  << std::endl;
-        return -1;
-      }
-      if ((get_cfg_reqlen() != HOSTEXE_CLS_1) &&
-          (he_lpbk_cfg_.TestMode == HOST_EXEMODE_LPBK1)) {
-        std::cerr << "Atomic function in lpbk mode requires cl_1" << std::endl;
-        return -1;
-      }
-    }
-
-    // Encoding
-    he_lpbk_cfg_.Encoding = host_exe_->he_req_encoding_;
-    if ((he_lpbk_cfg_.Encoding != HOSTEXE_ENCODING_DEFAULT) &&
-        (he_lpbk_api_ver_ == 0)) {
-      std::cerr << "Host exerciser hardware API version 0 does not support "
-                   "encoding changes"
-                << std::endl;
-      return -1;
-    }
-
-    if (host_exe_->he_continuousmode_ && (he_lpbk_cfg_.IntrTestMode == 1)) {
-      std::cerr << "Interrupts not supported in continuous mode" << std::endl;
-      return -1;
-    }
-
-    if (host_exe_->he_continuousmode_ && (host_exe_->he_contmodetime_ == 0)) {
-      std::cerr << "Please add cmd line input continuous mode time"
-                << std::endl;
-      return -1;
-    }
-
-    return 0;
-  }
-
-  // The test state has been configured. Run one test instance.
-  int run_single_test() {
-    int status = 0;
-
-    // Clear the status buffer
-    std::fill_n(dsm_->c_type(), LPBK1_DSM_SIZE, 0x0);
-
-    host_exe_->logger_->debug("Start Test");
-
-    // Write to CSR_CFG
-    host_exe_->write64(HE_CFG, he_lpbk_cfg_.value);
-    host_exe_->logger_->debug("Input Config: {0}", he_lpbk_cfg_.value);
-
-    event::ptr_t ev = nullptr;
-    if (he_lpbk_cfg_.IntrTestMode == 1) {
-      he_interrupt_.VectorNum = host_exe_->he_interrupt_;
-      host_exe_->write32(HE_INTERRUPT0, he_interrupt_.value);
-      ev = host_exe_->register_interrupt(host_exe_->he_interrupt_);
-      std::cout << "Using Interrupts\n";
-    }
-
-    if (host_exe_->logger_->should_log(spdlog::level::debug)) {
-      std::cout << std::endl;
-      he_dump_buffer(source_, "Pre-execution source");
-      he_dump_buffer(destination_, "Pre-execution destination");
-      std::cout << std::endl;
-    }
-
-    // Write to CSR_CTL
-    he_lpbk_ctl_.value = 0;
-    he_lpbk_ctl_.Start = 1;
-    he_lpbk_ctl_.ResetL = 1;
-    host_exe_->write32(HE_CTL, he_lpbk_ctl_.value);
-
-    // Interrupt test mode
-    if (he_lpbk_cfg_.IntrTestMode == 1) {
-      if (!he_interrupt(ev)) {
-        status = -1;
-        if (host_exe_->logger_->should_log(spdlog::level::debug)) {
-          std::cout << std::endl;
-          he_dump_buffer(source_, "Post-execution source");
-          he_dump_buffer(destination_, "Post-execution destination");
-          std::cout << std::endl;
+        // print bandwidth
+        if (dsm_num_ticks(dsm_status) > 0) {
+            double perf_data = he_num_xfers_to_bw(num_cache_lines, dsm_num_ticks(dsm_status));
+            host_exe_->logger_->info("Bandwidth: {0:0.3f} GB/s", perf_data);
         }
-      } else {
-        status = he_compare_buffer();
-        if (host_exe_->logger_->should_log(spdlog::level::debug)) {
-          std::cout << std::endl;
-          he_dump_buffer(source_, "Post-execution source");
-          he_dump_buffer(destination_, "Post-execution destination");
-          std::cout << std::endl;
-        }
-        he_perf_counters();
-      }
-    } else if (host_exe_->he_continuousmode_) {
-      // Continuous mode
-      he_continuousmode();
+    }
 
-      if (host_exe_->logger_->should_log(spdlog::level::debug)) {
-        std::cout << std::endl;
-        he_dump_buffer(source_, "Post-execution source");
-        he_dump_buffer(destination_, "Post-execution destination");
-        std::cout << std::endl;
-      }
-    } else {
-      // Regular mode
-      if (!he_wait_test_completion()) {
-        status = -1;
-      } else {
-        if (host_exe_->logger_->should_log(spdlog::level::debug)) {
-          std::cout << std::endl;
-          he_dump_buffer(source_, "Post-execution source");
-          he_dump_buffer(destination_, "Post-execution destination");
-          std::cout << std::endl;
+    bool he_interrupt(event::ptr_t ev)
+    {
+        try {
+            host_exe_->interrupt_wait(ev, 10000);
+            if (he_lpbk_cfg_.TestMode == HOST_EXEMODE_LPBK1)
+                host_exe_->compare(source_, destination_);
+        }
+        catch (std::exception &ex) {
+            std::cout << "Exception: " << ex.what() << std::endl;
+            host_exerciser_errors();
+            return false;
+        }
+        return true;
+    }
+
+    bool he_wait_test_completion()
+    {
+        /* Wait for test completion */
+        uint32_t timeout = HELPBK_TEST_TIMEOUT;
+        if (is_ase_sim_) {
+            // Much longer timeout when running HW simulation
+            timeout *= 100;
         }
 
-        status = he_compare_buffer();
-        he_perf_counters();
-      }
+        volatile uint8_t* status_ptr = dsm_->c_type();
+
+        while (0 == ((*status_ptr) & 0x1)) {
+            usleep(HELPBK_TEST_SLEEP_INVL);
+            if (--timeout == 0) {
+                std::cout << "HE LPBK TIME OUT" << std::endl;
+                host_exerciser_errors();
+                host_exerciser_status();
+                return false;
+            }
+        }
+        return true;
     }
 
-    // assert reset he-lpbk
-    he_lpbk_ctl_.value = 0;
-    host_exe_->write32(HE_CTL, he_lpbk_ctl_.value);
-    usleep(1000);
+    void he_forcetestcmpl()
+    {
+        // Force stop test
+        he_lpbk_ctl_.value = 0;
+        he_lpbk_ctl_.ResetL = 1;
+        he_lpbk_ctl_.ForcedTestCmpl = 1;
+        host_exe_->write32(HE_CTL, he_lpbk_ctl_.value);
 
-    // deassert reset he-lpbk
-    he_lpbk_ctl_.value = 0;
-    he_lpbk_ctl_.ResetL = 1;
-    host_exe_->write32(HE_CTL, he_lpbk_ctl_.value);
+        if (! he_wait_test_completion())
+            sleep(1);
 
-    return status;
-  }
-
-  // Sequence through all the test modes
-  int run_all_tests() {
-    int status = 0;
-
-    // Start with loopback tests
-    he_lpbk_cfg_.TestMode = HOST_EXEMODE_LPBK1;
-    he_lpbk_cfg_.AtomicFunc = HOSTEXE_ATOMIC_OFF;
-    host_exe_->he_continuousmode_ = false;
-    he_lpbk_cfg_.Continuous = 0;
-
-    // Test multiple request sizes
-    std::cout << std::endl
-              << "Testing loopback, varying payload size:" << std::endl;
-    for (std::map<std::string, uint32_t>::const_iterator cls =
-             he_req_cls_len.begin();
-         cls != he_req_cls_len.end(); ++cls) {
-      // Set request length
-      if (cls->second > he_lpbk_max_reqlen_) break;
-      set_cfg_reqlen(cls->second);
-
-      // Initialize buffer values
-      he_init_src_buffer(source_);
-      std::fill_n(destination_->c_type(), LPBK1_BUFFER_SIZE, 0xBE);
-
-      int test_status = run_single_test();
-      status |= test_status;
-
-      std::cout << "  " << cls->first << ": " << (test_status ? "FAIL" : "PASS")
-                << std::endl;
+        he_lpbk_ctl_.value = 0;
+        host_exe_->write32(HE_CTL, he_lpbk_ctl_.value);
+        usleep(1000);
     }
-    set_cfg_reqlen(HOSTEXE_CLS_1);
 
-    // Test atomic functions if the API supports it
-    if (he_lpbk_atomics_supported_) {
-      std::cout << std::endl << "Testing atomic functions:" << std::endl;
-      for (std::map<std::string, uint32_t>::const_iterator af =
-               he_req_atomic_func.begin();
-           af != he_req_atomic_func.end(); ++af) {
-        // Don't test "off"
-        if (af->second == HOSTEXE_ATOMIC_OFF) continue;
+    void he_init_src_buffer(shared_buffer::ptr_t buffer)
+    {
+        // Fill the source buffer with random values
+        host_exe_->fill(buffer);
 
-        he_lpbk_cfg_.AtomicFunc = af->second;
+        // Compare and swap? If so, seed the source buffers with values will
+        // match. The hardware tests uses the line index as the test.
+        if (he_lpbk_cfg_.AtomicFunc == HOSTEXE_ATOMIC_CAS_4) {
+            for (uint32_t i = 0; i < buffer->size()/CL; i += 3) {
+                buffer->write<uint32_t>(i, i*CL);
+            }
+        }
+        if (he_lpbk_cfg_.AtomicFunc == HOSTEXE_ATOMIC_CAS_8) {
+            for (uint32_t i = 0; i < buffer->size()/CL; i += 3) {
+                buffer->write<uint64_t>(i, i*CL);
+            }
+        }
 
-        // Initialize buffer values
-        he_init_src_buffer(source_);
-        std::fill_n(destination_->c_type(), LPBK1_BUFFER_SIZE, 0xBE);
+        // In atomic mode, at most the first 8 bytes of each line will be
+        // updated and copied. In the source buffer, write a function of
+        // the value at the start of each line to the second position so
+        // it can be used as a check later.
+        if (he_lpbk_cfg_.AtomicFunc != HOSTEXE_ATOMIC_OFF) {
+            for (uint32_t i = 0; i < buffer->size()/CL; i += 1) {
+                uint64_t v = buffer->read<uint64_t>(i*CL);
+                buffer->write<uint64_t>(v ^ 0xabababababababab, i*CL + 8);
+            }
+        }
+    }
 
-        int test_status = run_single_test();
-        status |= test_status;
+    void he_dump_buffer(shared_buffer::ptr_t buffer, const char* msg)
+    {
+        std::cout << msg << ":" << std::endl;
 
-        std::cout << "  " << af->first << ": "
-                  << (test_status ? "FAIL" : "PASS") << std::endl;
-      }
+        // Dump the first 8 lines of a buffer
+        for (uint64_t i = 0; i < 8; i++)
+        {
+            std::cout << std::hex
+                      << " " << std::setfill('0') << std::setw(16) << buffer->read<uint64_t>(i*CL + 8*7)
+                      << " " << std::setfill('0') << std::setw(16) << buffer->read<uint64_t>(i*CL + 8*6)
+                      << " " << std::setfill('0') << std::setw(16) << buffer->read<uint64_t>(i*CL + 8*5)
+                      << " " << std::setfill('0') << std::setw(16) << buffer->read<uint64_t>(i*CL + 8*4)
+                      << " " << std::setfill('0') << std::setw(16) << buffer->read<uint64_t>(i*CL + 8*3)
+                      << " " << std::setfill('0') << std::setw(16) << buffer->read<uint64_t>(i*CL + 8*2)
+                      << " " << std::setfill('0') << std::setw(16) << buffer->read<uint64_t>(i*CL + 8*1)
+                      << " " << std::setfill('0') << std::setw(16) << buffer->read<uint64_t>(i*CL)
+                      << std::dec << std::endl;
+        }
 
-      std::cout << std::endl
-                << "Testing atomic functions interspersed in continuous mode:"
+        std::cout << " ..." << std::endl;
+    }
+
+    uint64_t he_compare_buffer()
+    {
+        uint64_t status = host_exerciser_swtestmsg();
+        if (status) {
+            std::cerr << "HE LB CSR error flag is set" << std::endl;
+            return status;
+        }
+
+        // Compare buffer contents only loopback test mode
+        if (he_lpbk_cfg_.TestMode != HOST_EXEMODE_LPBK1)
+            return 0;
+
+        // Normal (non-atomic) is a simple comparison
+        if (he_lpbk_cfg_.AtomicFunc == HOSTEXE_ATOMIC_OFF) {
+            return (source_->compare(destination_, source_->size()));
+        }
+
+        // Atomic mode is a far more complicated comparison. The source buffer
+        // is modified and some of the original state is copied to the destination.
+        bool size_is_4 = ((he_lpbk_cfg_.AtomicFunc & 2) == 0);
+        bool is_fetch_add = (he_lpbk_cfg_.AtomicFunc & 0xc) == 0;
+        bool is_swap = (he_lpbk_cfg_.AtomicFunc & 0xc) == 4;
+        bool is_cas = (he_lpbk_cfg_.AtomicFunc & 0xc) == 8;
+
+        // Ignore the last entry to work around an off by one copy error
+        for (uint64_t i = 0; i < source_->size()/CL; i += 1) {
+            // In source_, the first entry in every line is the atomically modified
+            // value. The second entry holds the original value, hashed with a constant
+            // so it isn't a simple repetition.
+            uint64_t src_a = source_->read<uint64_t>(i*CL);
+            // Read the original value and reverse the hash.
+            uint64_t src_b = source_->read<uint64_t>(i*CL + 8) ^ 0xabababababababab;
+            uint64_t upd_a = 0;
+
+            // Compute expected value
+            if (is_fetch_add) {
+                // Hardware added the line index (i) to each line, either preserving
+                // the high 4 bytes or modifying all 8 bytes.
+                if (size_is_4)
+                    upd_a = (src_b & 0xffffffff00000000) | ((src_b + i) & 0xffffffff);
+                else
+                    upd_a = src_b + i;
+            }
+            if (is_swap) {
+                // Hardware swapped the line index (i) into each line
+                if (size_is_4)
+                    upd_a = (src_b & 0xffffffff00000000) | (i & 0xffffffff);
+                else
+                    upd_a = i;
+            }
+            if (is_cas) {
+                // Hardware swapped the bit inverse of line index (i) in each line when
+                // the original value is the line index.
+                if (size_is_4)
+                    upd_a = ((src_b & 0xffffffff) == i) ? (src_b & 0xffffffff00000000) | (~i & 0xffffffff) : src_b;
+                else
+                    upd_a = (src_b == i) ? ~i : src_b;
+            }
+
+            if (upd_a != src_a) {
+                std::cerr << "Atomic update error" << std::endl;
+                return 1;
+            }
+
+            // The destination is comparatively easy. For all functions it is
+            // simply the original source value.
+            uint64_t dst_a = destination_->read<uint64_t>(i*CL);
+            if (size_is_4) {
+                src_b &= 0xffffffff;
+                dst_a &= 0xffffffff;
+            }
+
+            if (dst_a != src_b) {
+                std::cerr << "Atomic read error or write error" << std::endl;
+                return 1;
+            }
+        }
+
+        return 0;
+    }
+
+    bool he_continuousmode()
+    {
+        uint32_t count = 0;
+        if (host_exe_->he_continuousmode_ && host_exe_->he_contmodetime_ > 0)
+        { 
+            host_exe_->logger_->debug("continuous mode time: {0} seconds", host_exe_->he_contmodetime_);
+            host_exe_->logger_->debug("Ctrl+C  to stop continuous mode");
+
+            while (!g_he_exit) {
+                sleep(1);
+                count++;
+                if (count > host_exe_->he_contmodetime_)
+                    break;
+            }
+            he_forcetestcmpl();
+            he_perf_counters();
+        }
+        return true;
+    }
+
+    inline void set_cfg_reqlen(hostexe_req_len req_len)
+    {
+        // Legal request lengths have grown over time, leading to the field being
+        // split in the configuration register.
+        he_lpbk_cfg_.ReqLen_High = req_len >> 2;
+        he_lpbk_cfg_.ReqLen = req_len & 3;
+    }
+
+    inline void set_cfg_reqlen(uint32_t req_len)
+    {
+        set_cfg_reqlen(static_cast<hostexe_req_len>(req_len));
+    }
+
+    inline hostexe_req_len get_cfg_reqlen()
+    {
+        return static_cast<hostexe_req_len>((he_lpbk_cfg_.ReqLen_High << 2) |
+                                            he_lpbk_cfg_.ReqLen);
+    }
+
+    int parse_input_options()
+    {
+
+        if (!host_exe_)
+            return -1;
+
+        // ASE simulation?
+        auto afu_props = fpga::properties::get(token_);
+        uint32_t vendor_id = afu_props->vendor_id;
+        uint32_t device_id = afu_props->device_id;
+        is_ase_sim_ = (vendor_id == 0x8086) && (device_id == 0xa5e);
+        if (is_ase_sim_) {
+            std::cout << "Simulation: ASE mode" << std::endl;
+        }
+
+        // Host Exerciser Mode
+        he_lpbk_cfg_.TestMode = host_exe_->he_modes_;
+
+        // Host Exerciser Read
+        if (host_exe_->he_req_cls_len_ > he_lpbk_max_reqlen_) {
+            std::cerr << "Request length " << host_exe_->he_req_cls_len_
+                      << " is not supported by this platform." << std::endl;
+            return -1;
+        }
+        set_cfg_reqlen(host_exe_->he_req_cls_len_);
+
+        // Host Exerciser  lpbk delay
+        if (host_exe_->he_delay_)
+             he_lpbk_cfg_.DelayEn = 1;
+
+        //test rollover or test termination
+        if (host_exe_->he_continuousmode_)
+             he_lpbk_cfg_.Continuous = 1;
+
+        // Set interleave in Throughput
+        if (he_lpbk_cfg_.TestMode == HOST_EXEMODE_TRPUT) {
+              he_lpbk_cfg_.TputInterleave = host_exe_->he_interleave_;
+        }
+
+        // Set Interrupt test mode
+        if (host_exe_->option_passed("--interrupt")) {
+            if (host_exe_->he_interrupt_ < afu_props->num_interrupts) {
+                he_lpbk_cfg_.IntrTestMode = 1;
+            } else {
+                std::cerr << "Invalid Input interrupts vector number:" << host_exe_->he_interrupt_ << std::endl;
+                std::cout << "Please enter Interrupts vector range 0 to " << afu_props->num_interrupts -1 << std::endl;
+                return -1;
+            }
+        }
+
+        // Atomic functions
+        he_lpbk_cfg_.AtomicFunc = host_exe_->he_req_atomic_func_;
+        if (he_lpbk_cfg_.AtomicFunc != HOSTEXE_ATOMIC_OFF) {
+            if (!he_lpbk_atomics_supported_) {
+                std::cerr << "The platform does not support atomic functions" << std::endl;
+                return -1;
+            }
+            if ((get_cfg_reqlen() != HOSTEXE_CLS_1) && (he_lpbk_cfg_.TestMode == HOST_EXEMODE_LPBK1)) {
+                std::cerr << "Atomic function in lpbk mode requires cl_1" << std::endl;
+                return -1;
+            }
+        }
+
+        // Encoding
+        he_lpbk_cfg_.Encoding = host_exe_->he_req_encoding_;
+        if ((he_lpbk_cfg_.Encoding != HOSTEXE_ENCODING_DEFAULT) && (he_lpbk_api_ver_ == 0)) {
+            std::cerr << "Host exerciser hardware API version 0 does not support encoding changes" << std::endl;
+            return -1;
+        }
+
+        if (host_exe_->he_continuousmode_  && 
+            (he_lpbk_cfg_.IntrTestMode == 1)) {
+            std::cerr << "Interrupts not supported in continuous mode"
                 << std::endl;
-      uint32_t trip = 0;
-      for (std::map<std::string, uint32_t>::const_reverse_iterator cls =
-               he_req_cls_len.rbegin();
-           cls != he_req_cls_len.rend(); ++cls) {
-        he_lpbk_cfg_.TestMode = HOST_EXEMODE_TRPUT;
+            return -1;
+        }
 
-        if (cls->second > he_lpbk_max_reqlen_) break;
-        set_cfg_reqlen(cls->second);
+        if (host_exe_->he_continuousmode_ &&
+            (host_exe_->he_contmodetime_ == 0)) {
+            std::cerr << "Please add cmd line input continuous mode time"
+                << std::endl;
+            return -1;
+        }
 
-        he_lpbk_cfg_.AtomicFunc =
-            (trip & 1 ? HOSTEXE_ATOMIC_FADD_4 : HOSTEXE_ATOMIC_CAS_8);
+        return 0;
+    }
+
+    // The test state has been configured. Run one test instance.
+    int run_single_test()
+    {
+        int status = 0;
+
+        // Clear the status buffer
+        std::fill_n(dsm_->c_type(), LPBK1_DSM_SIZE, 0x0);
+
+        host_exe_->logger_->debug("Start Test");
+
+        // Write to CSR_CFG
+        host_exe_->write64(HE_CFG, he_lpbk_cfg_.value);
+        host_exe_->logger_->debug("Input Config: {0}", he_lpbk_cfg_.value);
+
+        event::ptr_t ev = nullptr;
+        if (he_lpbk_cfg_.IntrTestMode == 1) {
+            he_interrupt_.VectorNum = host_exe_->he_interrupt_;
+            host_exe_->write32(HE_INTERRUPT0, he_interrupt_.value);
+            ev = host_exe_->register_interrupt(host_exe_->he_interrupt_);
+            std::cout << "Using Interrupts\n";
+        }
+
+        if (host_exe_->logger_->should_log(spdlog::level::debug)) {
+            std::cout << std::endl;
+            he_dump_buffer(source_, "Pre-execution source");
+            he_dump_buffer(destination_, "Pre-execution destination");
+            std::cout << std::endl;
+        }
+
+        // Write to CSR_CTL
+        he_lpbk_ctl_.value = 0;
+        he_lpbk_ctl_.Start = 1;
+        he_lpbk_ctl_.ResetL = 1;
+        host_exe_->write32(HE_CTL, he_lpbk_ctl_.value);
+
+        // Interrupt test mode
+        if (he_lpbk_cfg_.IntrTestMode == 1) {
+            if (!he_interrupt(ev)) {
+                status = -1;
+                if (host_exe_->logger_->should_log(spdlog::level::debug)) {
+                    std::cout << std::endl;
+                    he_dump_buffer(source_, "Post-execution source");
+                    he_dump_buffer(destination_, "Post-execution destination");
+                    std::cout << std::endl;
+                }
+            }
+            else {
+                status = he_compare_buffer();
+                if (host_exe_->logger_->should_log(spdlog::level::debug)) {
+                    std::cout << std::endl;
+                    he_dump_buffer(source_, "Post-execution source");
+                    he_dump_buffer(destination_, "Post-execution destination");
+                    std::cout << std::endl;
+                }
+                he_perf_counters();
+            }
+        } else if (host_exe_->he_continuousmode_) {
+            // Continuous mode
+            he_continuousmode();
+
+            if (host_exe_->logger_->should_log(spdlog::level::debug)) {
+                std::cout << std::endl;
+                he_dump_buffer(source_, "Post-execution source");
+                he_dump_buffer(destination_, "Post-execution destination");
+                std::cout << std::endl;
+            }
+        } else {
+            // Regular mode
+            if (!he_wait_test_completion()) {
+                status = -1;
+            }
+            else {
+                if (host_exe_->logger_->should_log(spdlog::level::debug)) {
+                    std::cout << std::endl;
+                    he_dump_buffer(source_, "Post-execution source");
+                    he_dump_buffer(destination_, "Post-execution destination");
+                    std::cout << std::endl;
+                }
+
+                status = he_compare_buffer();
+                he_perf_counters();
+            }
+        }
+
+        // assert reset he-lpbk
+        he_lpbk_ctl_.value = 0;
+        host_exe_->write32(HE_CTL, he_lpbk_ctl_.value);
+        usleep(1000);
+
+        // deassert reset he-lpbk
+        he_lpbk_ctl_.value = 0;
+        he_lpbk_ctl_.ResetL = 1;
+        host_exe_->write32(HE_CTL, he_lpbk_ctl_.value);
+
+        return status;
+    }
+
+    // Sequence through all the test modes
+    int run_all_tests()
+    {
+        int status = 0;
+
+        // Start with loopback tests
+        he_lpbk_cfg_.TestMode = HOST_EXEMODE_LPBK1;
+        he_lpbk_cfg_.AtomicFunc = HOSTEXE_ATOMIC_OFF;
+        host_exe_->he_continuousmode_ = false;
+        he_lpbk_cfg_.Continuous = 0;
+
+        // Test multiple request sizes
+        std::cout << std::endl << "Testing loopback, varying payload size:" << std::endl;
+        for (std::map<std::string, uint32_t>::const_iterator cls=he_req_cls_len.begin(); cls!=he_req_cls_len.end(); ++cls) {
+            // Set request length
+            if (cls->second > he_lpbk_max_reqlen_) break;
+            set_cfg_reqlen(cls->second);
+
+            // Initialize buffer values
+            he_init_src_buffer(source_);
+            std::fill_n(destination_->c_type(), LPBK1_BUFFER_SIZE, 0xBE);
+
+            int test_status = run_single_test();
+            status |= test_status;
+
+            std::cout << "  " << cls->first << ": "
+                      << (test_status ? "FAIL" : "PASS") << std::endl;
+        }
+        set_cfg_reqlen(HOSTEXE_CLS_1);
+
+        // Test atomic functions if the API supports it
+        if (he_lpbk_atomics_supported_) {
+            std::cout << std::endl << "Testing atomic functions:" << std::endl;
+            for (std::map<std::string, uint32_t>::const_iterator af=he_req_atomic_func.begin(); af!=he_req_atomic_func.end(); ++af) {
+                // Don't test "off"
+                if (af->second == HOSTEXE_ATOMIC_OFF) continue;
+
+                he_lpbk_cfg_.AtomicFunc = af->second;
+
+                // Initialize buffer values
+                he_init_src_buffer(source_);
+                std::fill_n(destination_->c_type(), LPBK1_BUFFER_SIZE, 0xBE);
+
+                int test_status = run_single_test();
+                status |= test_status;
+
+                std::cout << "  " << af->first << ": "
+                          << (test_status ? "FAIL" : "PASS") << std::endl;
+            }
+
+            std::cout << std::endl << "Testing atomic functions interspersed in continuous mode:" << std::endl;
+            uint32_t trip = 0;
+            for (std::map<std::string, uint32_t>::const_reverse_iterator cls=he_req_cls_len.rbegin(); cls!=he_req_cls_len.rend(); ++cls) {
+                he_lpbk_cfg_.TestMode = HOST_EXEMODE_TRPUT;
+
+                if (cls->second > he_lpbk_max_reqlen_) break;
+                set_cfg_reqlen(cls->second);
+
+                he_lpbk_cfg_.AtomicFunc = (trip & 1 ? HOSTEXE_ATOMIC_FADD_4 : HOSTEXE_ATOMIC_CAS_8);
+                host_exe_->he_continuousmode_ = true;
+                he_lpbk_cfg_.Continuous = 1;
+
+                int test_status = run_single_test();
+                status |= test_status;
+
+                std::cout << "  " << cls->first
+                          <<" and " << (trip & 1 ? "fadd_4" : "cas_8") << ": "
+                          << (test_status ? "FAIL" : "PASS") << std::endl;
+
+                trip += 1;
+            }
+
+            he_lpbk_cfg_.AtomicFunc = HOSTEXE_ATOMIC_OFF;
+        }
+
+        // Test throughput, varying read, write and size
+        std::cout << std::endl << "Testing throughput (GB/s), varying payload size ("
+                  << host_exe_->he_contmodetime_ << " seconds each):" << std::endl;
+        std::cout.setf(std::ios::fixed);
+        std::cout.precision(2);
+
+        // Get a pointer to the device status memory, needed to compute throughput
+        volatile he_dsm_status *dsm_status =
+            reinterpret_cast<he_dsm_status *>((uint8_t*)dsm_->c_type());
+
         host_exe_->he_continuousmode_ = true;
         he_lpbk_cfg_.Continuous = 1;
+        for (std::map<std::string, uint32_t>::const_iterator cls=he_req_cls_len.begin(); cls!=he_req_cls_len.end(); ++cls) {
+            if (cls->second > he_lpbk_max_reqlen_) break;
+            set_cfg_reqlen(cls->second);
 
-        int test_status = run_single_test();
-        status |= test_status;
+            he_lpbk_cfg_.TestMode = HOST_EXEMODE_READ;
+            int test_status = run_single_test();
+            status |= test_status;
+            std::cout << "  " << cls->first << " READ:  ";
+            if (test_status)
+                std::cout << "FAIL" << std::endl;
+            else {
+                std::cout << he_num_xfers_to_bw(dsm_num_reads(dsm_status), dsm_num_ticks(dsm_status))
+                          << std::endl;
+            }
 
-        std::cout << "  " << cls->first << " and "
-                  << (trip & 1 ? "fadd_4" : "cas_8") << ": "
-                  << (test_status ? "FAIL" : "PASS") << std::endl;
+            he_lpbk_cfg_.TestMode = HOST_EXEMODE_WRITE;
+            test_status = run_single_test();
+            status |= test_status;
+            std::cout << "  " << cls->first << " WRITE: ";
+            if (test_status)
+                std::cout << "FAIL" << std::endl;
+            else {
+                std::cout << he_num_xfers_to_bw(dsm_num_writes(dsm_status), dsm_num_ticks(dsm_status))
+                          << std::endl;
+            }
 
-        trip += 1;
-      }
+            he_lpbk_cfg_.TestMode = HOST_EXEMODE_TRPUT;
+            test_status = run_single_test();
+            status |= test_status;
+            std::cout << "  " << cls->first << " TRPUT: ";
+            if (test_status)
+                std::cout << "FAIL" << std::endl;
+            else {
+                std::cout << he_num_xfers_to_bw(dsm_num_reads(dsm_status) + dsm_num_writes(dsm_status),
+                                                dsm_num_ticks(dsm_status))
+                          << std::endl;
+            }
 
-      he_lpbk_cfg_.AtomicFunc = HOSTEXE_ATOMIC_OFF;
-    }
-
-    // Test throughput, varying read, write and size
-    std::cout << std::endl
-              << "Testing throughput (GB/s), varying payload size ("
-              << host_exe_->he_contmodetime_ << " seconds each):" << std::endl;
-    std::cout.setf(std::ios::fixed);
-    std::cout.precision(2);
-
-    // Get a pointer to the device status memory, needed to compute throughput
-    volatile he_dsm_status *dsm_status =
-        reinterpret_cast<he_dsm_status *>((uint8_t *)dsm_->c_type());
-
-    host_exe_->he_continuousmode_ = true;
-    he_lpbk_cfg_.Continuous = 1;
-    for (std::map<std::string, uint32_t>::const_iterator cls =
-             he_req_cls_len.begin();
-         cls != he_req_cls_len.end(); ++cls) {
-      if (cls->second > he_lpbk_max_reqlen_) break;
-      set_cfg_reqlen(cls->second);
-
-      he_lpbk_cfg_.TestMode = HOST_EXEMODE_READ;
-      int test_status = run_single_test();
-      status |= test_status;
-      std::cout << "  " << cls->first << " READ:  ";
-      if (test_status)
-        std::cout << "FAIL" << std::endl;
-      else {
-        std::cout << he_num_xfers_to_bw(dsm_num_reads(dsm_status),
-                                        dsm_num_ticks(dsm_status))
-                  << std::endl;
-      }
-
-      he_lpbk_cfg_.TestMode = HOST_EXEMODE_WRITE;
-      test_status = run_single_test();
-      status |= test_status;
-      std::cout << "  " << cls->first << " WRITE: ";
-      if (test_status)
-        std::cout << "FAIL" << std::endl;
-      else {
-        std::cout << he_num_xfers_to_bw(dsm_num_writes(dsm_status),
-                                        dsm_num_ticks(dsm_status))
-                  << std::endl;
-      }
-
-      he_lpbk_cfg_.TestMode = HOST_EXEMODE_TRPUT;
-      test_status = run_single_test();
-      status |= test_status;
-      std::cout << "  " << cls->first << " TRPUT: ";
-      if (test_status)
-        std::cout << "FAIL" << std::endl;
-      else {
-        std::cout << he_num_xfers_to_bw(
-                         dsm_num_reads(dsm_status) + dsm_num_writes(dsm_status),
-                         dsm_num_ticks(dsm_status))
-                  << std::endl;
-      }
-
-      std::cout << std::endl;
-    }
-
-    return status;
-  }
-
-  virtual int run(test_afu *afu, CLI::App *app) {
-    (void)app;
-
-    auto d_afu = dynamic_cast<host_exerciser *>(afu);
-    host_exe_ = dynamic_cast<host_exerciser *>(afu);
-
-    token_ = d_afu->get_token();
-    token_device_ = d_afu->get_token_device();
-
-    // Check if memory calibration has failed and error out before proceeding
-    // with the test. The dfl-emif driver creates sysfs entries to report the
-    // calibration status for each memory channel. sysobjects are the OPAE-API's
-    // abstraction for sysfs entries. However, at this time, these are only
-    // accessible through tokens that use the xfpga plugin and not the vfio
-    // plugin. Hence our use of the DEVICE token (token_device_). One
-    // non-ideality of the following implementation is the use of
-    // MAX_NUM_MEM_CHANNELS. We are essentially doing a brute-force query of
-    // sysfs entries since we don't know how many mem channels exist on the
-    // given platform. What about glob wildcards? Why not simply glob for
-    // "*dfl*/**/inf*_cal_fail" and use the OPAE-API's support for arrays of
-    // sysobjects? The reason is that, at the time of this writing, the
-    // xfpga-plugin's sysobject implementation does not support arrays
-    // specifically when the glob contains a recursive wildcard "/**/". It's a
-    // strange and perhaps unnecessary limitation. Therefore, future work is to
-    // fix that and clean up the code below.
-    for (size_t i = 0; i < MAX_NUM_MEM_CHANNELS; i++) {
-      std::stringstream mem_cal_glob;
-      mem_cal_glob << "*dfl*/**/inf" << i << "_cal_fail";
-      fpga::sysobject::ptr_t testobj = fpga::sysobject::get(
-          token_device_, mem_cal_glob.str().c_str(), FPGA_OBJECT_GLOB);
-      if (testobj) {
-        // Error out if calibration has failed
-        if (testobj->read64(0)) {  // Non-zero value (typically '1') means
-                                   // calibration has failed
-          std::cout
-              << "This sysfs entry reports that memory calibration has failed:"
-              << mem_cal_glob.str().c_str() << std::endl;
-          return -1;
+            std::cout << std::endl;
         }
-      }
+
+        return status;
     }
 
-    // Read HW details
-    uint64_t he_info = host_exe_->read64(HE_INFO0);
-    he_lpbk_api_ver_ = (he_info >> 16);
-    std::cout << "API version: " << uint32_t(he_lpbk_api_ver_) << std::endl;
+    virtual int run(test_afu *afu, CLI::App *app)
+    {
+        (void)app;
 
-    // For atomics support, the version must not be zero and bit 24 must be 0.
-    he_lpbk_atomics_supported_ =
-        (he_lpbk_api_ver_ != 0) && (0 == ((he_info >> 24) & 1));
+        auto d_afu = dynamic_cast<host_exerciser*>(afu);
+        host_exe_ = dynamic_cast<host_exerciser*>(afu);
 
-    // The maximum request length before API version 2 was 8.
-    he_lpbk_max_reqlen_ =
-        (he_lpbk_api_ver_ < 2) ? HOSTEXE_CLS_8 : HOSTEXE_CLS_16;
+        token_ = d_afu->get_token();
+        token_device_ = d_afu->get_token_device();
 
-    if (0 == host_exe_->he_clock_mhz_) {
-      uint16_t freq = he_info;
-      if (freq) {
-        host_exe_->he_clock_mhz_ = freq;
-        std::cout << "AFU clock: " << host_exe_->he_clock_mhz_ << " MHz"
-                  << std::endl;
-      } else {
-        host_exe_->he_clock_mhz_ = 350;
-        std::cout << "Frequency of AFU clock unknown. Assuming "
-                  << host_exe_->he_clock_mhz_ << " MHz." << std::endl;
-      }
-    } else {
-      std::cout << "AFU clock from command line: " << host_exe_->he_clock_mhz_
-                << " MHz" << std::endl;
+        // Check if memory calibration has failed and error out before proceeding with the test.
+        // The dfl-emif driver creates sysfs entries to report the calibration status for each memory channel.
+        // sysobjects are the OPAE-API's abstraction for sysfs entries. 
+        // However, at this time, these are only accessible through tokens that use the 
+        // xfpga plugin and not the vfio plugin. Hence our use of the DEVICE token (token_device_).
+        // One non-ideality of the following implementation is the use of MAX_NUM_MEM_CHANNELS.
+        // We are essentially doing a brute-force query of sysfs entries since we don't know how
+        // many mem channels exist on the given platform.
+        // What about glob wildcards? Why not simply glob for "*dfl*/**/inf*_cal_fail" and use
+        // the OPAE-API's support for arrays of sysobjects? The reason is that, at the time of this writing,
+        // the xfpga-plugin's sysobject implementation does not support arrays specifically when the glob contains
+        // a recursive wildcard "/**/". It's a strange and perhaps unnecessary limitation. Therefore, future work
+        // is to fix that and clean up the code below.
+        for (size_t i=0; i<MAX_NUM_MEM_CHANNELS;i++) {
+            std::stringstream mem_cal_glob;
+            mem_cal_glob << "*dfl*/**/inf" << i << "_cal_fail";
+            fpga::sysobject::ptr_t testobj = fpga::sysobject::get(token_device_,mem_cal_glob.str().c_str(),FPGA_OBJECT_GLOB);
+            if (testobj) {
+                // Error out if calibration has failed
+                if (testobj->read64(0)) { // Non-zero value (typically '1') means calibration has failed
+                    std::cout << "This sysfs entry reports that memory calibration has failed:" << mem_cal_glob.str().c_str() << std::endl;
+                    return -1;
+                }
+            }
+        }
+        
+        // Read HW details
+        uint64_t he_info = host_exe_->read64(HE_INFO0);
+        he_lpbk_api_ver_ = (he_info >> 16);
+        std::cout << "API version: " << uint32_t(he_lpbk_api_ver_) << std::endl;
+
+        // For atomics support, the version must not be zero and bit 24 must be 0.
+        he_lpbk_atomics_supported_ = (he_lpbk_api_ver_ != 0) &&
+                                     (0 == ((he_info >> 24) & 1));
+
+        // The maximum request length before API version 2 was 8.
+        he_lpbk_max_reqlen_ = (he_lpbk_api_ver_ < 2) ? HOSTEXE_CLS_8 : HOSTEXE_CLS_16;
+
+        if (0 == host_exe_->he_clock_mhz_) {
+            uint16_t freq = he_info;
+            if (freq) {
+                host_exe_->he_clock_mhz_ = freq;
+                std::cout << "AFU clock: "
+                          << host_exe_->he_clock_mhz_ << " MHz" << std::endl;
+            }
+            else {
+                host_exe_->he_clock_mhz_ = 350;
+                std::cout << "Frequency of AFU clock unknown. Assuming "
+                          << host_exe_->he_clock_mhz_ << " MHz." << std::endl;
+            }
+        }
+        else {
+            std::cout << "AFU clock from command line: "
+                      << host_exe_->he_clock_mhz_ << " MHz" << std::endl;
+        }
+
+        auto ret = parse_input_options();
+        if (ret != 0) {
+            std::cerr << "Failed to parse input options" << std::endl;
+            return ret;
+        }
+
+        // assert reset he-lpbk
+        he_lpbk_ctl_.value = 0;
+        d_afu->write32(HE_CTL, he_lpbk_ctl_.value);
+        usleep(1000);
+
+        // deassert reset he-lpbk
+        he_lpbk_ctl_.value = 0;
+        he_lpbk_ctl_.ResetL = 1;
+        d_afu->write32(HE_CTL, he_lpbk_ctl_.value);
+
+        /* Allocate Source Buffer
+        Write to CSR_SRC_ADDR */
+        std::cout << "Allocate SRC Buffer" << std::endl;
+        source_ = d_afu->allocate(LPBK1_BUFFER_ALLOCATION_SIZE);
+        host_exe_->logger_->debug("    VA 0x{0}  IOVA 0x{1:x}",
+                                  (void*)source_->c_type(), source_->io_address());
+        d_afu->write64(HE_SRC_ADDR, cacheline_aligned_addr(source_->io_address()));
+        he_init_src_buffer(source_);
+
+        /* Allocate Destination Buffer
+            Write to CSR_DST_ADDR */
+        std::cout << "Allocate DST Buffer" << std::endl;
+        destination_ = d_afu->allocate(LPBK1_BUFFER_ALLOCATION_SIZE);
+        host_exe_->logger_->debug("    VA 0x{0}  IOVA 0x{1:x}",
+                                  (void*)destination_->c_type(), destination_->io_address());
+        d_afu->write64(HE_DST_ADDR, cacheline_aligned_addr(destination_->io_address()));
+        std::fill_n(destination_->c_type(), LPBK1_BUFFER_SIZE, 0xBE);
+
+        /* Allocate DSM Buffer
+            Write to CSR_AFU_DSM_BASEL */
+        std::cout << "Allocate DSM Buffer" << std::endl;
+        dsm_ = d_afu->allocate(LPBK1_DSM_SIZE);
+        host_exe_->logger_->debug("    VA 0x{0}  IOVA 0x{1:x}",
+                                  (void*)dsm_->c_type(), dsm_->io_address());
+        d_afu->write32(HE_DSM_BASEL, cacheline_aligned_addr(dsm_->io_address()));
+        d_afu->write32(HE_DSM_BASEH, cacheline_aligned_addr(dsm_->io_address()) >> 32);
+        std::fill_n(dsm_->c_type(), LPBK1_DSM_SIZE, 0x0);
+
+        // Number of cache lines
+        d_afu->write64(HE_NUM_LINES, (LPBK1_BUFFER_SIZE / (1 * CL)) -1);
+
+        int status = 0;
+        if (host_exe_->he_test_all_)
+            status = run_all_tests();
+        else
+            status = run_single_test();
+
+        return status;
     }
 
-    auto ret = parse_input_options();
-    if (ret != 0) {
-      std::cerr << "Failed to parse input options" << std::endl;
-      return ret;
-    }
-
-    // assert reset he-lpbk
-    he_lpbk_ctl_.value = 0;
-    d_afu->write32(HE_CTL, he_lpbk_ctl_.value);
-    usleep(1000);
-
-    // deassert reset he-lpbk
-    he_lpbk_ctl_.value = 0;
-    he_lpbk_ctl_.ResetL = 1;
-    d_afu->write32(HE_CTL, he_lpbk_ctl_.value);
-
-    /* Allocate Source Buffer
-    Write to CSR_SRC_ADDR */
-    std::cout << "Allocate SRC Buffer" << std::endl;
-    source_ = d_afu->allocate(LPBK1_BUFFER_ALLOCATION_SIZE);
-    host_exe_->logger_->debug("    VA 0x{0}  IOVA 0x{1:x}",
-                              (void *)source_->c_type(), source_->io_address());
-    d_afu->write64(HE_SRC_ADDR, cacheline_aligned_addr(source_->io_address()));
-    he_init_src_buffer(source_);
-
-    /* Allocate Destination Buffer
-        Write to CSR_DST_ADDR */
-    std::cout << "Allocate DST Buffer" << std::endl;
-    destination_ = d_afu->allocate(LPBK1_BUFFER_ALLOCATION_SIZE);
-    host_exe_->logger_->debug("    VA 0x{0}  IOVA 0x{1:x}",
-                              (void *)destination_->c_type(),
-                              destination_->io_address());
-    d_afu->write64(HE_DST_ADDR,
-                   cacheline_aligned_addr(destination_->io_address()));
-    std::fill_n(destination_->c_type(), LPBK1_BUFFER_SIZE, 0xBE);
-
-    /* Allocate DSM Buffer
-        Write to CSR_AFU_DSM_BASEL */
-    std::cout << "Allocate DSM Buffer" << std::endl;
-    dsm_ = d_afu->allocate(LPBK1_DSM_SIZE);
-    host_exe_->logger_->debug("    VA 0x{0}  IOVA 0x{1:x}",
-                              (void *)dsm_->c_type(), dsm_->io_address());
-    d_afu->write32(HE_DSM_BASEL, cacheline_aligned_addr(dsm_->io_address()));
-    d_afu->write32(HE_DSM_BASEH,
-                   cacheline_aligned_addr(dsm_->io_address()) >> 32);
-    std::fill_n(dsm_->c_type(), LPBK1_DSM_SIZE, 0x0);
-
-    // Number of cache lines
-    d_afu->write64(HE_NUM_LINES, (LPBK1_BUFFER_SIZE / (1 * CL)) - 1);
-
-    int status = 0;
-    if (host_exe_->he_test_all_)
-      status = run_all_tests();
-    else
-      status = run_single_test();
-
-    return status;
-  }
-
- protected:
-  he_cfg he_lpbk_cfg_;
-  he_ctl he_lpbk_ctl_;
-  host_exerciser *host_exe_;
-  shared_buffer::ptr_t source_;
-  shared_buffer::ptr_t destination_;
-  shared_buffer::ptr_t dsm_;
-  he_interrupt0 he_interrupt_;
-  token::ptr_t token_;
-  token::ptr_t token_device_;
-  hostexe_req_len he_lpbk_max_reqlen_;
-  uint8_t he_lpbk_api_ver_;
-  bool he_lpbk_atomics_supported_;
-  bool is_ase_sim_;
+protected:
+    he_cfg he_lpbk_cfg_;
+    he_ctl he_lpbk_ctl_;
+    host_exerciser *host_exe_;
+    shared_buffer::ptr_t source_;
+    shared_buffer::ptr_t destination_;
+    shared_buffer::ptr_t dsm_;
+    he_interrupt0 he_interrupt_;
+    token::ptr_t token_;
+    token::ptr_t token_device_;
+    hostexe_req_len he_lpbk_max_reqlen_;
+    uint8_t he_lpbk_api_ver_;
+    bool he_lpbk_atomics_supported_;
+    bool is_ase_sim_;
 };
 
-}  // end of namespace host_exerciser
+} // end of namespace host_exerciser
+

--- a/samples/host_exerciser/host_exerciser_cmd.h
+++ b/samples/host_exerciser/host_exerciser_cmd.h
@@ -739,32 +739,40 @@ public:
         token_ = d_afu->get_token();
         token_device_ = d_afu->get_token_device();
 
-        // Check if memory calibration has failed and error out before proceeding with the test.
-        // The dfl-emif driver creates sysfs entries to report the calibration status for each memory channel.
-        // sysobjects are the OPAE-API's abstraction for sysfs entries. 
-        // However, at this time, these are only accessible through tokens that use the 
-        // xfpga plugin and not the vfio plugin. Hence our use of the DEVICE token (token_device_).
-        // One non-ideality of the following implementation is the use of MAX_NUM_MEM_CHANNELS.
-        // We are essentially doing a brute-force query of sysfs entries since we don't know how
-        // many mem channels exist on the given platform.
-        // What about glob wildcards? Why not simply glob for "*dfl*/**/inf*_cal_fail" and use
-        // the OPAE-API's support for arrays of sysobjects? The reason is that, at the time of this writing,
-        // the xfpga-plugin's sysobject implementation does not support arrays specifically when the glob contains
-        // a recursive wildcard "/**/". It's a strange and perhaps unnecessary limitation. Therefore, future work
-        // is to fix that and clean up the code below.
-        for (size_t i=0; i<MAX_NUM_MEM_CHANNELS;i++) {
-            std::stringstream mem_cal_glob;
-            mem_cal_glob << "*dfl*/**/inf" << i << "_cal_fail";
-            fpga::sysobject::ptr_t testobj = fpga::sysobject::get(token_device_,mem_cal_glob.str().c_str(),FPGA_OBJECT_GLOB);
-            if (testobj) {
-                // Error out if calibration has failed
-                if (testobj->read64(0)) { // Non-zero value (typically '1') means calibration has failed
-                    std::cout << "This sysfs entry reports that memory calibration has failed:" << mem_cal_glob.str().c_str() << std::endl;
-                    return -1;
-                }
+        // Check if memory calibration has failed and error out before proceeding
+        // with the test. The dfl-emif driver creates sysfs entries to report the
+        // calibration status for each memory channel. sysobjects are the OPAE-API's
+        // abstraction for sysfs entries. However, at this time, these are only
+        // accessible through tokens that use the xfpga plugin and not the vfio
+        // plugin. Hence our use of the DEVICE token (token_device_). One
+        // non-ideality of the following implementation is the use of
+        // MAX_NUM_MEM_CHANNELS. We are essentially doing a brute-force query of
+        // sysfs entries since we don't know how many mem channels exist on the
+        // given platform. What about glob wildcards? Why not simply glob for
+        // "*dfl*/**/inf*_cal_fail" and use the OPAE-API's support for arrays of
+        // sysobjects? The reason is that, at the time of this writing, the
+        // xfpga-plugin's sysobject implementation does not support arrays
+        // specifically when the glob contains a recursive wildcard "/**/". It's a
+        // strange and perhaps unnecessary limitation. Therefore, future work is to
+        // fix that and clean up the code below.
+        for (size_t i = 0; i < MAX_NUM_MEM_CHANNELS; i++) {
+          std::stringstream mem_cal_glob;
+          mem_cal_glob << "*dfl*/**/inf" << i << "_cal_fail";
+          fpga::sysobject::ptr_t testobj = fpga::sysobject::get(
+              token_device_, mem_cal_glob.str().c_str(), FPGA_OBJECT_GLOB);
+          if (testobj) {
+            // Error out if calibration has failed
+            if (testobj->read64(0)) {  // Non-zero value (typically '1') means
+                                       // calibration has failed
+              std::cout
+                  << "This sysfs entry reports that memory calibration has failed:"
+                  << mem_cal_glob.str().c_str() << std::endl;
+              return -1;
             }
+          }
         }
-        
+
+
         // Read HW details
         uint64_t he_info = host_exe_->read64(HE_INFO0);
         he_lpbk_api_ver_ = (he_info >> 16);

--- a/samples/host_exerciser/host_exerciser_cmd.h
+++ b/samples/host_exerciser/host_exerciser_cmd.h
@@ -27,10 +27,10 @@
 
 #include <unistd.h>
 
+#include <opae/cxx/core.h>
+#include <opae/types_enum.h>
 #include "afu_test.h"
 #include "host_exerciser.h"
-#include <opae/types_enum.h>
-#include <opae/cxx/core.h>
 
 using test_afu = opae::afu_test::afu;
 using opae::fpga::types::shared_buffer;
@@ -41,831 +41,829 @@ namespace fpga = opae::fpga::types;
 volatile bool g_he_exit = false;
 
 // host exerciser signal handler
-void he_sig_handler(int)
-{
-    g_he_exit = true;
-    printf("HE signal handler exit app \n");
+void he_sig_handler(int) {
+  g_he_exit = true;
+  printf("HE signal handler exit app \n");
 }
 
 namespace host_exerciser {
 
+class host_exerciser_cmd : public test_command {
+ public:
+  host_exerciser_cmd() : host_exe_(NULL) {
+    he_lpbk_cfg_.value = 0;
+    he_lpbk_ctl_.value = 0;
+    he_lpbk_max_reqlen_ = HOSTEXE_CLS_8;
+    he_lpbk_api_ver_ = 0;
+    he_lpbk_atomics_supported_ = false;
+    is_ase_sim_ = false;
+  }
+  virtual ~host_exerciser_cmd() {}
 
-class host_exerciser_cmd : public test_command
-{
-public:
-    host_exerciser_cmd()
-        :host_exe_(NULL) {
-          he_lpbk_cfg_.value = 0;
-          he_lpbk_ctl_.value = 0;
-          he_lpbk_max_reqlen_ = HOSTEXE_CLS_8;
-          he_lpbk_api_ver_ = 0;
-          he_lpbk_atomics_supported_ = false;
-          is_ase_sim_ = false;
-    }
-    virtual ~host_exerciser_cmd() {}
+  void host_exerciser_status() {
+    he_status0 he_status0;
+    he_status1 he_status1;
 
-    void host_exerciser_status()
-    {
-        he_status0 he_status0;
-        he_status1 he_status1;
+    he_status0.value = host_exe_->read64(HE_STATUS0);
+    he_status1.value = host_exe_->read64(HE_STATUS1);
 
-        he_status0.value = host_exe_->read64(HE_STATUS0);
-        he_status1.value = host_exe_->read64(HE_STATUS1);
+    uint64_t tmp;
 
-        uint64_t tmp;
+    tmp = he_status0.numReads;
+    host_exe_->logger_->info("Host Exerciser numReads: {0}", tmp);
+    tmp = he_status0.numWrites;
+    host_exe_->logger_->info("Host Exerciser numWrites: {0}", tmp);
 
-        tmp = he_status0.numReads;
-        host_exe_->logger_->info("Host Exerciser numReads: {0}", tmp);
-        tmp = he_status0.numWrites;
-        host_exe_->logger_->info("Host Exerciser numWrites: {0}", tmp);
+    tmp = he_status1.numPendReads;
+    host_exe_->logger_->info("Host Exerciser numPendReads: {0}", tmp);
+    tmp = he_status1.numPendWrites;
+    host_exe_->logger_->info("Host Exerciser numPendWrites: {0}", tmp);
 
-        tmp = he_status1.numPendReads;
-        host_exe_->logger_->info("Host Exerciser numPendReads: {0}", tmp);
-        tmp = he_status1.numPendWrites;
-        host_exe_->logger_->info("Host Exerciser numPendWrites: {0}", tmp);
+    tmp = he_status1.numPendEmifReads;
+    host_exe_->logger_->info("Host Exerciser numPendEmifReads: {0}", tmp);
+    tmp = he_status1.numPendEmifWrites;
+    host_exe_->logger_->info("Host Exerciser numPendEmifWrites: {0}", tmp);
+  }
 
-        tmp = he_status1.numPendEmifReads;
-        host_exe_->logger_->info("Host Exerciser numPendEmifReads: {0}", tmp);
-        tmp = he_status1.numPendEmifWrites;
-        host_exe_->logger_->info("Host Exerciser numPendEmifWrites: {0}", tmp);
-    }
+  void host_exerciser_errors() {
+    he_error he_error;
 
-    void host_exerciser_errors()
-    {
-        he_error he_error;
+    if (host_exe_ == NULL) return;
 
-        if (host_exe_ == NULL)
-            return;
+    he_error.value = host_exe_->read64(HE_ERROR);
 
-        he_error.value = host_exe_->read64(HE_ERROR);
+    std::cout << "Host Exerciser Error:" << he_error.error << std::endl;
+  }
 
-        std::cout << "Host Exerciser Error:" << he_error.error << std::endl;
+  uint64_t host_exerciser_swtestmsg() {
+    uint64_t swtest_msg;
 
-    }
+    if (host_exe_ == NULL) return 0;
 
-    uint64_t host_exerciser_swtestmsg()
-    {
-        uint64_t swtest_msg;
-
-        if (host_exe_ == NULL)
-            return 0;
-
-        swtest_msg = host_exe_->read64(HE_SWTEST_MSG);
-        if (swtest_msg) {
-            std::cout << "Host Exerciser swtest msg:" << swtest_msg << std::endl;
-        }
-
-        return swtest_msg;
+    swtest_msg = host_exe_->read64(HE_SWTEST_MSG);
+    if (swtest_msg) {
+      std::cout << "Host Exerciser swtest msg:" << swtest_msg << std::endl;
     }
 
-    inline uint64_t cacheline_aligned_addr(uint64_t num) {
-        return num >> LOG2_CL;
+    return swtest_msg;
+  }
+
+  inline uint64_t cacheline_aligned_addr(uint64_t num) {
+    return num >> LOG2_CL;
+  }
+
+  // Convert number of transactions to bandwidth (GB/s)
+  double he_num_xfers_to_bw(uint64_t num_lines, uint64_t num_ticks) {
+    return (double)(num_lines * 64) /
+           ((1000.0 / host_exe_->he_clock_mhz_ * num_ticks));
+  }
+
+  inline uint64_t dsm_num_ticks(const volatile he_dsm_status *dsm_status) {
+    return dsm_status->num_ticks;
+  }
+
+  // Read count has two parts -- the size was increased after the first release
+  inline uint64_t dsm_num_reads(const volatile he_dsm_status *dsm_status) {
+    return (uint64_t(dsm_status->num_reads_h) << 32) | dsm_status->num_reads_l;
+  }
+
+  // Write count has two parts -- the size was increased after the first release
+  inline uint64_t dsm_num_writes(const volatile he_dsm_status *dsm_status) {
+    return (uint64_t(dsm_status->num_writes_h) << 32) |
+           dsm_status->num_writes_l;
+  }
+
+  void he_perf_counters() {
+    volatile he_dsm_status *dsm_status = NULL;
+    volatile uint8_t *status_ptr = dsm_->c_type();
+    uint64_t num_cache_lines = 0;
+    if (!status_ptr) return;
+
+    dsm_status = reinterpret_cast<he_dsm_status *>((uint8_t *)status_ptr);
+    if (!dsm_status) return;
+
+    host_exe_->logger_->info("Host Exerciser Performance Counter:");
+    // calculate number of cache lines in continuous mode
+    if (host_exe_->he_continuousmode_) {
+      if (he_lpbk_cfg_.TestMode == HOST_EXEMODE_READ)
+        num_cache_lines = dsm_num_reads(dsm_status);
+      else if (he_lpbk_cfg_.TestMode == HOST_EXEMODE_WRITE)
+        num_cache_lines = (dsm_num_writes(dsm_status));
+      else
+        num_cache_lines =
+            dsm_num_reads(dsm_status) + dsm_num_writes(dsm_status);
+    } else {
+      num_cache_lines = (LPBK1_BUFFER_SIZE / (1 * CL));
     }
 
-    // Convert number of transactions to bandwidth (GB/s)
-    double he_num_xfers_to_bw(uint64_t num_lines, uint64_t num_ticks)
-    {
-        return (double)(num_lines * 64) / ((1000.0 / host_exe_->he_clock_mhz_ * num_ticks));
+    host_exerciser_status();
+
+    uint64_t tmp;
+
+    tmp = dsm_num_ticks(dsm_status);
+    host_exe_->logger_->info("Number of clocks: {0}", tmp);
+    tmp = dsm_num_reads(dsm_status);
+    host_exe_->logger_->info("Total number of Reads sent: {0}", tmp);
+    tmp = dsm_num_writes(dsm_status);
+    host_exe_->logger_->info("Total number of Writes sent: {0}", tmp);
+
+    // print bandwidth
+    if (dsm_num_ticks(dsm_status) > 0) {
+      double perf_data =
+          he_num_xfers_to_bw(num_cache_lines, dsm_num_ticks(dsm_status));
+      host_exe_->logger_->info("Bandwidth: {0:0.3f} GB/s", perf_data);
+    }
+  }
+
+  bool he_interrupt(event::ptr_t ev) {
+    try {
+      host_exe_->interrupt_wait(ev, 10000);
+      if (he_lpbk_cfg_.TestMode == HOST_EXEMODE_LPBK1)
+        host_exe_->compare(source_, destination_);
+    } catch (std::exception &ex) {
+      std::cout << "Exception: " << ex.what() << std::endl;
+      host_exerciser_errors();
+      return false;
+    }
+    return true;
+  }
+
+  bool he_wait_test_completion() {
+    /* Wait for test completion */
+    uint32_t timeout = HELPBK_TEST_TIMEOUT;
+    if (is_ase_sim_) {
+      // Much longer timeout when running HW simulation
+      timeout *= 100;
     }
 
-    inline uint64_t dsm_num_ticks(const volatile he_dsm_status *dsm_status)
-    {
-        return dsm_status->num_ticks;
-    }
+    volatile uint8_t *status_ptr = dsm_->c_type();
 
-    // Read count has two parts -- the size was increased after the first release
-    inline uint64_t dsm_num_reads(const volatile he_dsm_status *dsm_status)
-    {
-        return (uint64_t(dsm_status->num_reads_h) << 32) | dsm_status->num_reads_l;
-    }
-
-    // Write count has two parts -- the size was increased after the first release
-    inline uint64_t dsm_num_writes(const volatile he_dsm_status *dsm_status)
-    {
-        return (uint64_t(dsm_status->num_writes_h) << 32) | dsm_status->num_writes_l;
-    }
-
-    void he_perf_counters()
-    {
-        volatile he_dsm_status *dsm_status = NULL;
-        volatile uint8_t* status_ptr = dsm_->c_type();
-        uint64_t num_cache_lines = 0;
-        if (!status_ptr)
-           return;
-
-        dsm_status = reinterpret_cast<he_dsm_status *>((uint8_t*)status_ptr);
-        if (!dsm_status)
-            return;
-
-        host_exe_->logger_->info("Host Exerciser Performance Counter:");
-        // calculate number of cache lines in continuous mode
-        if (host_exe_->he_continuousmode_) {
-            if (he_lpbk_cfg_.TestMode == HOST_EXEMODE_READ)
-                num_cache_lines = dsm_num_reads(dsm_status);
-            else if (he_lpbk_cfg_.TestMode == HOST_EXEMODE_WRITE)
-                num_cache_lines = (dsm_num_writes(dsm_status));
-            else
-                num_cache_lines = dsm_num_reads(dsm_status) + dsm_num_writes(dsm_status);
-        } else {
-            num_cache_lines = (LPBK1_BUFFER_SIZE / (1 * CL));
-        }
-
+    while (0 == ((*status_ptr) & 0x1)) {
+      usleep(HELPBK_TEST_SLEEP_INVL);
+      if (--timeout == 0) {
+        std::cout << "HE LPBK TIME OUT" << std::endl;
+        host_exerciser_errors();
         host_exerciser_status();
+        return false;
+      }
+    }
+    return true;
+  }
 
-        uint64_t tmp;
+  void he_forcetestcmpl() {
+    // Force stop test
+    he_lpbk_ctl_.value = 0;
+    he_lpbk_ctl_.ResetL = 1;
+    he_lpbk_ctl_.ForcedTestCmpl = 1;
+    host_exe_->write32(HE_CTL, he_lpbk_ctl_.value);
 
-        tmp = dsm_num_ticks(dsm_status);
-        host_exe_->logger_->info("Number of clocks: {0}", tmp);
-        tmp = dsm_num_reads(dsm_status);
-        host_exe_->logger_->info("Total number of Reads sent: {0}", tmp);
-        tmp = dsm_num_writes(dsm_status);
-        host_exe_->logger_->info("Total number of Writes sent: {0}", tmp);
+    if (!he_wait_test_completion()) sleep(1);
 
-        // print bandwidth
-        if (dsm_num_ticks(dsm_status) > 0) {
-            double perf_data = he_num_xfers_to_bw(num_cache_lines, dsm_num_ticks(dsm_status));
-            host_exe_->logger_->info("Bandwidth: {0:0.3f} GB/s", perf_data);
-        }
+    he_lpbk_ctl_.value = 0;
+    host_exe_->write32(HE_CTL, he_lpbk_ctl_.value);
+    usleep(1000);
+  }
+
+  void he_init_src_buffer(shared_buffer::ptr_t buffer) {
+    // Fill the source buffer with random values
+    host_exe_->fill(buffer);
+
+    // Compare and swap? If so, seed the source buffers with values will
+    // match. The hardware tests uses the line index as the test.
+    if (he_lpbk_cfg_.AtomicFunc == HOSTEXE_ATOMIC_CAS_4) {
+      for (uint32_t i = 0; i < buffer->size() / CL; i += 3) {
+        buffer->write<uint32_t>(i, i * CL);
+      }
+    }
+    if (he_lpbk_cfg_.AtomicFunc == HOSTEXE_ATOMIC_CAS_8) {
+      for (uint32_t i = 0; i < buffer->size() / CL; i += 3) {
+        buffer->write<uint64_t>(i, i * CL);
+      }
     }
 
-    bool he_interrupt(event::ptr_t ev)
-    {
-        try {
-            host_exe_->interrupt_wait(ev, 10000);
-            if (he_lpbk_cfg_.TestMode == HOST_EXEMODE_LPBK1)
-                host_exe_->compare(source_, destination_);
-        }
-        catch (std::exception &ex) {
-            std::cout << "Exception: " << ex.what() << std::endl;
-            host_exerciser_errors();
-            return false;
-        }
-        return true;
+    // In atomic mode, at most the first 8 bytes of each line will be
+    // updated and copied. In the source buffer, write a function of
+    // the value at the start of each line to the second position so
+    // it can be used as a check later.
+    if (he_lpbk_cfg_.AtomicFunc != HOSTEXE_ATOMIC_OFF) {
+      for (uint32_t i = 0; i < buffer->size() / CL; i += 1) {
+        uint64_t v = buffer->read<uint64_t>(i * CL);
+        buffer->write<uint64_t>(v ^ 0xabababababababab, i * CL + 8);
+      }
+    }
+  }
+
+  void he_dump_buffer(shared_buffer::ptr_t buffer, const char *msg) {
+    std::cout << msg << ":" << std::endl;
+
+    // Dump the first 8 lines of a buffer
+    for (uint64_t i = 0; i < 8; i++) {
+      std::cout << std::hex << " " << std::setfill('0') << std::setw(16)
+                << buffer->read<uint64_t>(i * CL + 8 * 7) << " "
+                << std::setfill('0') << std::setw(16)
+                << buffer->read<uint64_t>(i * CL + 8 * 6) << " "
+                << std::setfill('0') << std::setw(16)
+                << buffer->read<uint64_t>(i * CL + 8 * 5) << " "
+                << std::setfill('0') << std::setw(16)
+                << buffer->read<uint64_t>(i * CL + 8 * 4) << " "
+                << std::setfill('0') << std::setw(16)
+                << buffer->read<uint64_t>(i * CL + 8 * 3) << " "
+                << std::setfill('0') << std::setw(16)
+                << buffer->read<uint64_t>(i * CL + 8 * 2) << " "
+                << std::setfill('0') << std::setw(16)
+                << buffer->read<uint64_t>(i * CL + 8 * 1) << " "
+                << std::setfill('0') << std::setw(16)
+                << buffer->read<uint64_t>(i * CL) << std::dec << std::endl;
     }
 
-    bool he_wait_test_completion()
-    {
-        /* Wait for test completion */
-        uint32_t timeout = HELPBK_TEST_TIMEOUT;
-        if (is_ase_sim_) {
-            // Much longer timeout when running HW simulation
-            timeout *= 100;
-        }
+    std::cout << " ..." << std::endl;
+  }
 
-        volatile uint8_t* status_ptr = dsm_->c_type();
-
-        while (0 == ((*status_ptr) & 0x1)) {
-            usleep(HELPBK_TEST_SLEEP_INVL);
-            if (--timeout == 0) {
-                std::cout << "HE LPBK TIME OUT" << std::endl;
-                host_exerciser_errors();
-                host_exerciser_status();
-                return false;
-            }
-        }
-        return true;
+  uint64_t he_compare_buffer() {
+    uint64_t status = host_exerciser_swtestmsg();
+    if (status) {
+      std::cerr << "HE LB CSR error flag is set" << std::endl;
+      return status;
     }
 
-    void he_forcetestcmpl()
-    {
-        // Force stop test
-        he_lpbk_ctl_.value = 0;
-        he_lpbk_ctl_.ResetL = 1;
-        he_lpbk_ctl_.ForcedTestCmpl = 1;
-        host_exe_->write32(HE_CTL, he_lpbk_ctl_.value);
+    // Compare buffer contents only loopback test mode
+    if (he_lpbk_cfg_.TestMode != HOST_EXEMODE_LPBK1) return 0;
 
-        if (! he_wait_test_completion())
-            sleep(1);
-
-        he_lpbk_ctl_.value = 0;
-        host_exe_->write32(HE_CTL, he_lpbk_ctl_.value);
-        usleep(1000);
+    // Normal (non-atomic) is a simple comparison
+    if (he_lpbk_cfg_.AtomicFunc == HOSTEXE_ATOMIC_OFF) {
+      return (source_->compare(destination_, source_->size()));
     }
 
-    void he_init_src_buffer(shared_buffer::ptr_t buffer)
-    {
-        // Fill the source buffer with random values
-        host_exe_->fill(buffer);
+    // Atomic mode is a far more complicated comparison. The source buffer
+    // is modified and some of the original state is copied to the destination.
+    bool size_is_4 = ((he_lpbk_cfg_.AtomicFunc & 2) == 0);
+    bool is_fetch_add = (he_lpbk_cfg_.AtomicFunc & 0xc) == 0;
+    bool is_swap = (he_lpbk_cfg_.AtomicFunc & 0xc) == 4;
+    bool is_cas = (he_lpbk_cfg_.AtomicFunc & 0xc) == 8;
 
-        // Compare and swap? If so, seed the source buffers with values will
-        // match. The hardware tests uses the line index as the test.
-        if (he_lpbk_cfg_.AtomicFunc == HOSTEXE_ATOMIC_CAS_4) {
-            for (uint32_t i = 0; i < buffer->size()/CL; i += 3) {
-                buffer->write<uint32_t>(i, i*CL);
-            }
-        }
-        if (he_lpbk_cfg_.AtomicFunc == HOSTEXE_ATOMIC_CAS_8) {
-            for (uint32_t i = 0; i < buffer->size()/CL; i += 3) {
-                buffer->write<uint64_t>(i, i*CL);
-            }
-        }
+    // Ignore the last entry to work around an off by one copy error
+    for (uint64_t i = 0; i < source_->size() / CL; i += 1) {
+      // In source_, the first entry in every line is the atomically modified
+      // value. The second entry holds the original value, hashed with a
+      // constant so it isn't a simple repetition.
+      uint64_t src_a = source_->read<uint64_t>(i * CL);
+      // Read the original value and reverse the hash.
+      uint64_t src_b = source_->read<uint64_t>(i * CL + 8) ^ 0xabababababababab;
+      uint64_t upd_a = 0;
 
-        // In atomic mode, at most the first 8 bytes of each line will be
-        // updated and copied. In the source buffer, write a function of
-        // the value at the start of each line to the second position so
-        // it can be used as a check later.
-        if (he_lpbk_cfg_.AtomicFunc != HOSTEXE_ATOMIC_OFF) {
-            for (uint32_t i = 0; i < buffer->size()/CL; i += 1) {
-                uint64_t v = buffer->read<uint64_t>(i*CL);
-                buffer->write<uint64_t>(v ^ 0xabababababababab, i*CL + 8);
-            }
-        }
+      // Compute expected value
+      if (is_fetch_add) {
+        // Hardware added the line index (i) to each line, either preserving
+        // the high 4 bytes or modifying all 8 bytes.
+        if (size_is_4)
+          upd_a = (src_b & 0xffffffff00000000) | ((src_b + i) & 0xffffffff);
+        else
+          upd_a = src_b + i;
+      }
+      if (is_swap) {
+        // Hardware swapped the line index (i) into each line
+        if (size_is_4)
+          upd_a = (src_b & 0xffffffff00000000) | (i & 0xffffffff);
+        else
+          upd_a = i;
+      }
+      if (is_cas) {
+        // Hardware swapped the bit inverse of line index (i) in each line when
+        // the original value is the line index.
+        if (size_is_4)
+          upd_a = ((src_b & 0xffffffff) == i)
+                      ? (src_b & 0xffffffff00000000) | (~i & 0xffffffff)
+                      : src_b;
+        else
+          upd_a = (src_b == i) ? ~i : src_b;
+      }
+
+      if (upd_a != src_a) {
+        std::cerr << "Atomic update error" << std::endl;
+        return 1;
+      }
+
+      // The destination is comparatively easy. For all functions it is
+      // simply the original source value.
+      uint64_t dst_a = destination_->read<uint64_t>(i * CL);
+      if (size_is_4) {
+        src_b &= 0xffffffff;
+        dst_a &= 0xffffffff;
+      }
+
+      if (dst_a != src_b) {
+        std::cerr << "Atomic read error or write error" << std::endl;
+        return 1;
+      }
     }
 
-    void he_dump_buffer(shared_buffer::ptr_t buffer, const char* msg)
-    {
-        std::cout << msg << ":" << std::endl;
+    return 0;
+  }
 
-        // Dump the first 8 lines of a buffer
-        for (uint64_t i = 0; i < 8; i++)
-        {
-            std::cout << std::hex
-                      << " " << std::setfill('0') << std::setw(16) << buffer->read<uint64_t>(i*CL + 8*7)
-                      << " " << std::setfill('0') << std::setw(16) << buffer->read<uint64_t>(i*CL + 8*6)
-                      << " " << std::setfill('0') << std::setw(16) << buffer->read<uint64_t>(i*CL + 8*5)
-                      << " " << std::setfill('0') << std::setw(16) << buffer->read<uint64_t>(i*CL + 8*4)
-                      << " " << std::setfill('0') << std::setw(16) << buffer->read<uint64_t>(i*CL + 8*3)
-                      << " " << std::setfill('0') << std::setw(16) << buffer->read<uint64_t>(i*CL + 8*2)
-                      << " " << std::setfill('0') << std::setw(16) << buffer->read<uint64_t>(i*CL + 8*1)
-                      << " " << std::setfill('0') << std::setw(16) << buffer->read<uint64_t>(i*CL)
-                      << std::dec << std::endl;
-        }
+  bool he_continuousmode() {
+    uint32_t count = 0;
+    if (host_exe_->he_continuousmode_ && host_exe_->he_contmodetime_ > 0) {
+      host_exe_->logger_->debug("continuous mode time: {0} seconds",
+                                host_exe_->he_contmodetime_);
+      host_exe_->logger_->debug("Ctrl+C  to stop continuous mode");
 
-        std::cout << " ..." << std::endl;
+      while (!g_he_exit) {
+        sleep(1);
+        count++;
+        if (count > host_exe_->he_contmodetime_) break;
+      }
+      he_forcetestcmpl();
+      he_perf_counters();
+    }
+    return true;
+  }
+
+  inline void set_cfg_reqlen(hostexe_req_len req_len) {
+    // Legal request lengths have grown over time, leading to the field being
+    // split in the configuration register.
+    he_lpbk_cfg_.ReqLen_High = req_len >> 2;
+    he_lpbk_cfg_.ReqLen = req_len & 3;
+  }
+
+  inline void set_cfg_reqlen(uint32_t req_len) {
+    set_cfg_reqlen(static_cast<hostexe_req_len>(req_len));
+  }
+
+  inline hostexe_req_len get_cfg_reqlen() {
+    return static_cast<hostexe_req_len>((he_lpbk_cfg_.ReqLen_High << 2) |
+                                        he_lpbk_cfg_.ReqLen);
+  }
+
+  int parse_input_options() {
+    if (!host_exe_) return -1;
+
+    // ASE simulation?
+    auto afu_props = fpga::properties::get(token_);
+    uint32_t vendor_id = afu_props->vendor_id;
+    uint32_t device_id = afu_props->device_id;
+    is_ase_sim_ = (vendor_id == 0x8086) && (device_id == 0xa5e);
+    if (is_ase_sim_) {
+      std::cout << "Simulation: ASE mode" << std::endl;
     }
 
-    uint64_t he_compare_buffer()
-    {
-        uint64_t status = host_exerciser_swtestmsg();
-        if (status) {
-            std::cerr << "HE LB CSR error flag is set" << std::endl;
-            return status;
-        }
+    // Host Exerciser Mode
+    he_lpbk_cfg_.TestMode = host_exe_->he_modes_;
 
-        // Compare buffer contents only loopback test mode
-        if (he_lpbk_cfg_.TestMode != HOST_EXEMODE_LPBK1)
-            return 0;
+    // Host Exerciser Read
+    if (host_exe_->he_req_cls_len_ > he_lpbk_max_reqlen_) {
+      std::cerr << "Request length " << host_exe_->he_req_cls_len_
+                << " is not supported by this platform." << std::endl;
+      return -1;
+    }
+    set_cfg_reqlen(host_exe_->he_req_cls_len_);
 
-        // Normal (non-atomic) is a simple comparison
-        if (he_lpbk_cfg_.AtomicFunc == HOSTEXE_ATOMIC_OFF) {
-            return (source_->compare(destination_, source_->size()));
-        }
+    // Host Exerciser  lpbk delay
+    if (host_exe_->he_delay_) he_lpbk_cfg_.DelayEn = 1;
 
-        // Atomic mode is a far more complicated comparison. The source buffer
-        // is modified and some of the original state is copied to the destination.
-        bool size_is_4 = ((he_lpbk_cfg_.AtomicFunc & 2) == 0);
-        bool is_fetch_add = (he_lpbk_cfg_.AtomicFunc & 0xc) == 0;
-        bool is_swap = (he_lpbk_cfg_.AtomicFunc & 0xc) == 4;
-        bool is_cas = (he_lpbk_cfg_.AtomicFunc & 0xc) == 8;
+    // test rollover or test termination
+    if (host_exe_->he_continuousmode_) he_lpbk_cfg_.Continuous = 1;
 
-        // Ignore the last entry to work around an off by one copy error
-        for (uint64_t i = 0; i < source_->size()/CL; i += 1) {
-            // In source_, the first entry in every line is the atomically modified
-            // value. The second entry holds the original value, hashed with a constant
-            // so it isn't a simple repetition.
-            uint64_t src_a = source_->read<uint64_t>(i*CL);
-            // Read the original value and reverse the hash.
-            uint64_t src_b = source_->read<uint64_t>(i*CL + 8) ^ 0xabababababababab;
-            uint64_t upd_a = 0;
-
-            // Compute expected value
-            if (is_fetch_add) {
-                // Hardware added the line index (i) to each line, either preserving
-                // the high 4 bytes or modifying all 8 bytes.
-                if (size_is_4)
-                    upd_a = (src_b & 0xffffffff00000000) | ((src_b + i) & 0xffffffff);
-                else
-                    upd_a = src_b + i;
-            }
-            if (is_swap) {
-                // Hardware swapped the line index (i) into each line
-                if (size_is_4)
-                    upd_a = (src_b & 0xffffffff00000000) | (i & 0xffffffff);
-                else
-                    upd_a = i;
-            }
-            if (is_cas) {
-                // Hardware swapped the bit inverse of line index (i) in each line when
-                // the original value is the line index.
-                if (size_is_4)
-                    upd_a = ((src_b & 0xffffffff) == i) ? (src_b & 0xffffffff00000000) | (~i & 0xffffffff) : src_b;
-                else
-                    upd_a = (src_b == i) ? ~i : src_b;
-            }
-
-            if (upd_a != src_a) {
-                std::cerr << "Atomic update error" << std::endl;
-                return 1;
-            }
-
-            // The destination is comparatively easy. For all functions it is
-            // simply the original source value.
-            uint64_t dst_a = destination_->read<uint64_t>(i*CL);
-            if (size_is_4) {
-                src_b &= 0xffffffff;
-                dst_a &= 0xffffffff;
-            }
-
-            if (dst_a != src_b) {
-                std::cerr << "Atomic read error or write error" << std::endl;
-                return 1;
-            }
-        }
-
-        return 0;
+    // Set interleave in Throughput
+    if (he_lpbk_cfg_.TestMode == HOST_EXEMODE_TRPUT) {
+      he_lpbk_cfg_.TputInterleave = host_exe_->he_interleave_;
     }
 
-    bool he_continuousmode()
-    {
-        uint32_t count = 0;
-        if (host_exe_->he_continuousmode_ && host_exe_->he_contmodetime_ > 0)
-        { 
-            host_exe_->logger_->debug("continuous mode time: {0} seconds", host_exe_->he_contmodetime_);
-            host_exe_->logger_->debug("Ctrl+C  to stop continuous mode");
-
-            while (!g_he_exit) {
-                sleep(1);
-                count++;
-                if (count > host_exe_->he_contmodetime_)
-                    break;
-            }
-            he_forcetestcmpl();
-            he_perf_counters();
-        }
-        return true;
+    // Set Interrupt test mode
+    if (host_exe_->option_passed("--interrupt")) {
+      if (host_exe_->he_interrupt_ < afu_props->num_interrupts) {
+        he_lpbk_cfg_.IntrTestMode = 1;
+      } else {
+        std::cerr << "Invalid Input interrupts vector number:"
+                  << host_exe_->he_interrupt_ << std::endl;
+        std::cout << "Please enter Interrupts vector range 0 to "
+                  << afu_props->num_interrupts - 1 << std::endl;
+        return -1;
+      }
     }
 
-    inline void set_cfg_reqlen(hostexe_req_len req_len)
-    {
-        // Legal request lengths have grown over time, leading to the field being
-        // split in the configuration register.
-        he_lpbk_cfg_.ReqLen_High = req_len >> 2;
-        he_lpbk_cfg_.ReqLen = req_len & 3;
+    // Atomic functions
+    he_lpbk_cfg_.AtomicFunc = host_exe_->he_req_atomic_func_;
+    if (he_lpbk_cfg_.AtomicFunc != HOSTEXE_ATOMIC_OFF) {
+      if (!he_lpbk_atomics_supported_) {
+        std::cerr << "The platform does not support atomic functions"
+                  << std::endl;
+        return -1;
+      }
+      if ((get_cfg_reqlen() != HOSTEXE_CLS_1) &&
+          (he_lpbk_cfg_.TestMode == HOST_EXEMODE_LPBK1)) {
+        std::cerr << "Atomic function in lpbk mode requires cl_1" << std::endl;
+        return -1;
+      }
     }
 
-    inline void set_cfg_reqlen(uint32_t req_len)
-    {
-        set_cfg_reqlen(static_cast<hostexe_req_len>(req_len));
-    }
-
-    inline hostexe_req_len get_cfg_reqlen()
-    {
-        return static_cast<hostexe_req_len>((he_lpbk_cfg_.ReqLen_High << 2) |
-                                            he_lpbk_cfg_.ReqLen);
-    }
-
-    int parse_input_options()
-    {
-
-        if (!host_exe_)
-            return -1;
-
-        // ASE simulation?
-        auto afu_props = fpga::properties::get(token_);
-        uint32_t vendor_id = afu_props->vendor_id;
-        uint32_t device_id = afu_props->device_id;
-        is_ase_sim_ = (vendor_id == 0x8086) && (device_id == 0xa5e);
-        if (is_ase_sim_) {
-            std::cout << "Simulation: ASE mode" << std::endl;
-        }
-
-        // Host Exerciser Mode
-        he_lpbk_cfg_.TestMode = host_exe_->he_modes_;
-
-        // Host Exerciser Read
-        if (host_exe_->he_req_cls_len_ > he_lpbk_max_reqlen_) {
-            std::cerr << "Request length " << host_exe_->he_req_cls_len_
-                      << " is not supported by this platform." << std::endl;
-            return -1;
-        }
-        set_cfg_reqlen(host_exe_->he_req_cls_len_);
-
-        // Host Exerciser  lpbk delay
-        if (host_exe_->he_delay_)
-             he_lpbk_cfg_.DelayEn = 1;
-
-        //test rollover or test termination
-        if (host_exe_->he_continuousmode_)
-             he_lpbk_cfg_.Continuous = 1;
-
-        // Set interleave in Throughput
-        if (he_lpbk_cfg_.TestMode == HOST_EXEMODE_TRPUT) {
-              he_lpbk_cfg_.TputInterleave = host_exe_->he_interleave_;
-        }
-
-        // Set Interrupt test mode
-        if (host_exe_->option_passed("--interrupt")) {
-            if (host_exe_->he_interrupt_ < afu_props->num_interrupts) {
-                he_lpbk_cfg_.IntrTestMode = 1;
-            } else {
-                std::cerr << "Invalid Input interrupts vector number:" << host_exe_->he_interrupt_ << std::endl;
-                std::cout << "Please enter Interrupts vector range 0 to " << afu_props->num_interrupts -1 << std::endl;
-                return -1;
-            }
-        }
-
-        // Atomic functions
-        he_lpbk_cfg_.AtomicFunc = host_exe_->he_req_atomic_func_;
-        if (he_lpbk_cfg_.AtomicFunc != HOSTEXE_ATOMIC_OFF) {
-            if (!he_lpbk_atomics_supported_) {
-                std::cerr << "The platform does not support atomic functions" << std::endl;
-                return -1;
-            }
-            if ((get_cfg_reqlen() != HOSTEXE_CLS_1) && (he_lpbk_cfg_.TestMode == HOST_EXEMODE_LPBK1)) {
-                std::cerr << "Atomic function in lpbk mode requires cl_1" << std::endl;
-                return -1;
-            }
-        }
-
-        // Encoding
-        he_lpbk_cfg_.Encoding = host_exe_->he_req_encoding_;
-        if ((he_lpbk_cfg_.Encoding != HOSTEXE_ENCODING_DEFAULT) && (he_lpbk_api_ver_ == 0)) {
-            std::cerr << "Host exerciser hardware API version 0 does not support encoding changes" << std::endl;
-            return -1;
-        }
-
-        if (host_exe_->he_continuousmode_  && 
-            (he_lpbk_cfg_.IntrTestMode == 1)) {
-            std::cerr << "Interrupts not supported in continuous mode"
+    // Encoding
+    he_lpbk_cfg_.Encoding = host_exe_->he_req_encoding_;
+    if ((he_lpbk_cfg_.Encoding != HOSTEXE_ENCODING_DEFAULT) &&
+        (he_lpbk_api_ver_ == 0)) {
+      std::cerr << "Host exerciser hardware API version 0 does not support "
+                   "encoding changes"
                 << std::endl;
-            return -1;
-        }
-
-        if (host_exe_->he_continuousmode_ &&
-            (host_exe_->he_contmodetime_ == 0)) {
-            std::cerr << "Please add cmd line input continuous mode time"
-                << std::endl;
-            return -1;
-        }
-
-        return 0;
+      return -1;
     }
 
-    // The test state has been configured. Run one test instance.
-    int run_single_test()
-    {
-        int status = 0;
+    if (host_exe_->he_continuousmode_ && (he_lpbk_cfg_.IntrTestMode == 1)) {
+      std::cerr << "Interrupts not supported in continuous mode" << std::endl;
+      return -1;
+    }
 
-        // Clear the status buffer
-        std::fill_n(dsm_->c_type(), LPBK1_DSM_SIZE, 0x0);
+    if (host_exe_->he_continuousmode_ && (host_exe_->he_contmodetime_ == 0)) {
+      std::cerr << "Please add cmd line input continuous mode time"
+                << std::endl;
+      return -1;
+    }
 
-        host_exe_->logger_->debug("Start Test");
+    return 0;
+  }
 
-        // Write to CSR_CFG
-        host_exe_->write64(HE_CFG, he_lpbk_cfg_.value);
-        host_exe_->logger_->debug("Input Config: {0}", he_lpbk_cfg_.value);
+  // The test state has been configured. Run one test instance.
+  int run_single_test() {
+    int status = 0;
 
-        event::ptr_t ev = nullptr;
-        if (he_lpbk_cfg_.IntrTestMode == 1) {
-            he_interrupt_.VectorNum = host_exe_->he_interrupt_;
-            host_exe_->write32(HE_INTERRUPT0, he_interrupt_.value);
-            ev = host_exe_->register_interrupt(host_exe_->he_interrupt_);
-            std::cout << "Using Interrupts\n";
-        }
+    // Clear the status buffer
+    std::fill_n(dsm_->c_type(), LPBK1_DSM_SIZE, 0x0);
 
+    host_exe_->logger_->debug("Start Test");
+
+    // Write to CSR_CFG
+    host_exe_->write64(HE_CFG, he_lpbk_cfg_.value);
+    host_exe_->logger_->debug("Input Config: {0}", he_lpbk_cfg_.value);
+
+    event::ptr_t ev = nullptr;
+    if (he_lpbk_cfg_.IntrTestMode == 1) {
+      he_interrupt_.VectorNum = host_exe_->he_interrupt_;
+      host_exe_->write32(HE_INTERRUPT0, he_interrupt_.value);
+      ev = host_exe_->register_interrupt(host_exe_->he_interrupt_);
+      std::cout << "Using Interrupts\n";
+    }
+
+    if (host_exe_->logger_->should_log(spdlog::level::debug)) {
+      std::cout << std::endl;
+      he_dump_buffer(source_, "Pre-execution source");
+      he_dump_buffer(destination_, "Pre-execution destination");
+      std::cout << std::endl;
+    }
+
+    // Write to CSR_CTL
+    he_lpbk_ctl_.value = 0;
+    he_lpbk_ctl_.Start = 1;
+    he_lpbk_ctl_.ResetL = 1;
+    host_exe_->write32(HE_CTL, he_lpbk_ctl_.value);
+
+    // Interrupt test mode
+    if (he_lpbk_cfg_.IntrTestMode == 1) {
+      if (!he_interrupt(ev)) {
+        status = -1;
         if (host_exe_->logger_->should_log(spdlog::level::debug)) {
-            std::cout << std::endl;
-            he_dump_buffer(source_, "Pre-execution source");
-            he_dump_buffer(destination_, "Pre-execution destination");
-            std::cout << std::endl;
+          std::cout << std::endl;
+          he_dump_buffer(source_, "Post-execution source");
+          he_dump_buffer(destination_, "Post-execution destination");
+          std::cout << std::endl;
+        }
+      } else {
+        status = he_compare_buffer();
+        if (host_exe_->logger_->should_log(spdlog::level::debug)) {
+          std::cout << std::endl;
+          he_dump_buffer(source_, "Post-execution source");
+          he_dump_buffer(destination_, "Post-execution destination");
+          std::cout << std::endl;
+        }
+        he_perf_counters();
+      }
+    } else if (host_exe_->he_continuousmode_) {
+      // Continuous mode
+      he_continuousmode();
+
+      if (host_exe_->logger_->should_log(spdlog::level::debug)) {
+        std::cout << std::endl;
+        he_dump_buffer(source_, "Post-execution source");
+        he_dump_buffer(destination_, "Post-execution destination");
+        std::cout << std::endl;
+      }
+    } else {
+      // Regular mode
+      if (!he_wait_test_completion()) {
+        status = -1;
+      } else {
+        if (host_exe_->logger_->should_log(spdlog::level::debug)) {
+          std::cout << std::endl;
+          he_dump_buffer(source_, "Post-execution source");
+          he_dump_buffer(destination_, "Post-execution destination");
+          std::cout << std::endl;
         }
 
-        // Write to CSR_CTL
-        he_lpbk_ctl_.value = 0;
-        he_lpbk_ctl_.Start = 1;
-        he_lpbk_ctl_.ResetL = 1;
-        host_exe_->write32(HE_CTL, he_lpbk_ctl_.value);
-
-        // Interrupt test mode
-        if (he_lpbk_cfg_.IntrTestMode == 1) {
-            if (!he_interrupt(ev)) {
-                status = -1;
-                if (host_exe_->logger_->should_log(spdlog::level::debug)) {
-                    std::cout << std::endl;
-                    he_dump_buffer(source_, "Post-execution source");
-                    he_dump_buffer(destination_, "Post-execution destination");
-                    std::cout << std::endl;
-                }
-            }
-            else {
-                status = he_compare_buffer();
-                if (host_exe_->logger_->should_log(spdlog::level::debug)) {
-                    std::cout << std::endl;
-                    he_dump_buffer(source_, "Post-execution source");
-                    he_dump_buffer(destination_, "Post-execution destination");
-                    std::cout << std::endl;
-                }
-                he_perf_counters();
-            }
-        } else if (host_exe_->he_continuousmode_) {
-            // Continuous mode
-            he_continuousmode();
-
-            if (host_exe_->logger_->should_log(spdlog::level::debug)) {
-                std::cout << std::endl;
-                he_dump_buffer(source_, "Post-execution source");
-                he_dump_buffer(destination_, "Post-execution destination");
-                std::cout << std::endl;
-            }
-        } else {
-            // Regular mode
-            if (!he_wait_test_completion()) {
-                status = -1;
-            }
-            else {
-                if (host_exe_->logger_->should_log(spdlog::level::debug)) {
-                    std::cout << std::endl;
-                    he_dump_buffer(source_, "Post-execution source");
-                    he_dump_buffer(destination_, "Post-execution destination");
-                    std::cout << std::endl;
-                }
-
-                status = he_compare_buffer();
-                he_perf_counters();
-            }
-        }
-
-        // assert reset he-lpbk
-        he_lpbk_ctl_.value = 0;
-        host_exe_->write32(HE_CTL, he_lpbk_ctl_.value);
-        usleep(1000);
-
-        // deassert reset he-lpbk
-        he_lpbk_ctl_.value = 0;
-        he_lpbk_ctl_.ResetL = 1;
-        host_exe_->write32(HE_CTL, he_lpbk_ctl_.value);
-
-        return status;
+        status = he_compare_buffer();
+        he_perf_counters();
+      }
     }
 
-    // Sequence through all the test modes
-    int run_all_tests()
-    {
-        int status = 0;
+    // assert reset he-lpbk
+    he_lpbk_ctl_.value = 0;
+    host_exe_->write32(HE_CTL, he_lpbk_ctl_.value);
+    usleep(1000);
 
-        // Start with loopback tests
-        he_lpbk_cfg_.TestMode = HOST_EXEMODE_LPBK1;
-        he_lpbk_cfg_.AtomicFunc = HOSTEXE_ATOMIC_OFF;
-        host_exe_->he_continuousmode_ = false;
-        he_lpbk_cfg_.Continuous = 0;
+    // deassert reset he-lpbk
+    he_lpbk_ctl_.value = 0;
+    he_lpbk_ctl_.ResetL = 1;
+    host_exe_->write32(HE_CTL, he_lpbk_ctl_.value);
 
-        // Test multiple request sizes
-        std::cout << std::endl << "Testing loopback, varying payload size:" << std::endl;
-        for (std::map<std::string, uint32_t>::const_iterator cls=he_req_cls_len.begin(); cls!=he_req_cls_len.end(); ++cls) {
-            // Set request length
-            if (cls->second > he_lpbk_max_reqlen_) break;
-            set_cfg_reqlen(cls->second);
+    return status;
+  }
 
-            // Initialize buffer values
-            he_init_src_buffer(source_);
-            std::fill_n(destination_->c_type(), LPBK1_BUFFER_SIZE, 0xBE);
+  // Sequence through all the test modes
+  int run_all_tests() {
+    int status = 0;
 
-            int test_status = run_single_test();
-            status |= test_status;
+    // Start with loopback tests
+    he_lpbk_cfg_.TestMode = HOST_EXEMODE_LPBK1;
+    he_lpbk_cfg_.AtomicFunc = HOSTEXE_ATOMIC_OFF;
+    host_exe_->he_continuousmode_ = false;
+    he_lpbk_cfg_.Continuous = 0;
 
-            std::cout << "  " << cls->first << ": "
-                      << (test_status ? "FAIL" : "PASS") << std::endl;
-        }
-        set_cfg_reqlen(HOSTEXE_CLS_1);
+    // Test multiple request sizes
+    std::cout << std::endl
+              << "Testing loopback, varying payload size:" << std::endl;
+    for (std::map<std::string, uint32_t>::const_iterator cls =
+             he_req_cls_len.begin();
+         cls != he_req_cls_len.end(); ++cls) {
+      // Set request length
+      if (cls->second > he_lpbk_max_reqlen_) break;
+      set_cfg_reqlen(cls->second);
 
-        // Test atomic functions if the API supports it
-        if (he_lpbk_atomics_supported_) {
-            std::cout << std::endl << "Testing atomic functions:" << std::endl;
-            for (std::map<std::string, uint32_t>::const_iterator af=he_req_atomic_func.begin(); af!=he_req_atomic_func.end(); ++af) {
-                // Don't test "off"
-                if (af->second == HOSTEXE_ATOMIC_OFF) continue;
+      // Initialize buffer values
+      he_init_src_buffer(source_);
+      std::fill_n(destination_->c_type(), LPBK1_BUFFER_SIZE, 0xBE);
 
-                he_lpbk_cfg_.AtomicFunc = af->second;
+      int test_status = run_single_test();
+      status |= test_status;
 
-                // Initialize buffer values
-                he_init_src_buffer(source_);
-                std::fill_n(destination_->c_type(), LPBK1_BUFFER_SIZE, 0xBE);
-
-                int test_status = run_single_test();
-                status |= test_status;
-
-                std::cout << "  " << af->first << ": "
-                          << (test_status ? "FAIL" : "PASS") << std::endl;
-            }
-
-            std::cout << std::endl << "Testing atomic functions interspersed in continuous mode:" << std::endl;
-            uint32_t trip = 0;
-            for (std::map<std::string, uint32_t>::const_reverse_iterator cls=he_req_cls_len.rbegin(); cls!=he_req_cls_len.rend(); ++cls) {
-                he_lpbk_cfg_.TestMode = HOST_EXEMODE_TRPUT;
-
-                if (cls->second > he_lpbk_max_reqlen_) break;
-                set_cfg_reqlen(cls->second);
-
-                he_lpbk_cfg_.AtomicFunc = (trip & 1 ? HOSTEXE_ATOMIC_FADD_4 : HOSTEXE_ATOMIC_CAS_8);
-                host_exe_->he_continuousmode_ = true;
-                he_lpbk_cfg_.Continuous = 1;
-
-                int test_status = run_single_test();
-                status |= test_status;
-
-                std::cout << "  " << cls->first
-                          <<" and " << (trip & 1 ? "fadd_4" : "cas_8") << ": "
-                          << (test_status ? "FAIL" : "PASS") << std::endl;
-
-                trip += 1;
-            }
-
-            he_lpbk_cfg_.AtomicFunc = HOSTEXE_ATOMIC_OFF;
-        }
-
-        // Test throughput, varying read, write and size
-        std::cout << std::endl << "Testing throughput (GB/s), varying payload size ("
-                  << host_exe_->he_contmodetime_ << " seconds each):" << std::endl;
-        std::cout.setf(std::ios::fixed);
-        std::cout.precision(2);
-
-        // Get a pointer to the device status memory, needed to compute throughput
-        volatile he_dsm_status *dsm_status =
-            reinterpret_cast<he_dsm_status *>((uint8_t*)dsm_->c_type());
-
-        host_exe_->he_continuousmode_ = true;
-        he_lpbk_cfg_.Continuous = 1;
-        for (std::map<std::string, uint32_t>::const_iterator cls=he_req_cls_len.begin(); cls!=he_req_cls_len.end(); ++cls) {
-            if (cls->second > he_lpbk_max_reqlen_) break;
-            set_cfg_reqlen(cls->second);
-
-            he_lpbk_cfg_.TestMode = HOST_EXEMODE_READ;
-            int test_status = run_single_test();
-            status |= test_status;
-            std::cout << "  " << cls->first << " READ:  ";
-            if (test_status)
-                std::cout << "FAIL" << std::endl;
-            else {
-                std::cout << he_num_xfers_to_bw(dsm_num_reads(dsm_status), dsm_num_ticks(dsm_status))
-                          << std::endl;
-            }
-
-            he_lpbk_cfg_.TestMode = HOST_EXEMODE_WRITE;
-            test_status = run_single_test();
-            status |= test_status;
-            std::cout << "  " << cls->first << " WRITE: ";
-            if (test_status)
-                std::cout << "FAIL" << std::endl;
-            else {
-                std::cout << he_num_xfers_to_bw(dsm_num_writes(dsm_status), dsm_num_ticks(dsm_status))
-                          << std::endl;
-            }
-
-            he_lpbk_cfg_.TestMode = HOST_EXEMODE_TRPUT;
-            test_status = run_single_test();
-            status |= test_status;
-            std::cout << "  " << cls->first << " TRPUT: ";
-            if (test_status)
-                std::cout << "FAIL" << std::endl;
-            else {
-                std::cout << he_num_xfers_to_bw(dsm_num_reads(dsm_status) + dsm_num_writes(dsm_status),
-                                                dsm_num_ticks(dsm_status))
-                          << std::endl;
-            }
-
-            std::cout << std::endl;
-        }
-
-        return status;
+      std::cout << "  " << cls->first << ": " << (test_status ? "FAIL" : "PASS")
+                << std::endl;
     }
+    set_cfg_reqlen(HOSTEXE_CLS_1);
 
-    virtual int run(test_afu *afu, CLI::App *app)
-    {
-        (void)app;
+    // Test atomic functions if the API supports it
+    if (he_lpbk_atomics_supported_) {
+      std::cout << std::endl << "Testing atomic functions:" << std::endl;
+      for (std::map<std::string, uint32_t>::const_iterator af =
+               he_req_atomic_func.begin();
+           af != he_req_atomic_func.end(); ++af) {
+        // Don't test "off"
+        if (af->second == HOSTEXE_ATOMIC_OFF) continue;
 
-        auto d_afu = dynamic_cast<host_exerciser*>(afu);
-        host_exe_ = dynamic_cast<host_exerciser*>(afu);
+        he_lpbk_cfg_.AtomicFunc = af->second;
 
-        token_ = d_afu->get_token();
-        token_device_ = d_afu->get_token_device();
-
-        // Check if memory calibration has failed and error out before proceeding with the test.
-        // The dfl-emif driver creates sysfs entries to report the calibration status for each memory channel.
-        // sysobjects are the OPAE-API's abstraction for sysfs entries. 
-        // However, at this time, these are only accessible through tokens that use the 
-        // xfpga plugin and not the vfio plugin. Hence our use of the DEVICE token (token_device_).
-        // One non-ideality of the following implementation is the use of MAX_NUM_MEM_CHANNELS.
-        // We are essentially doing a brute-force query of sysfs entries since we don't know how
-        // many mem channels exist on the given platform.
-        // What about glob wildcards? Why not simply glob for "*dfl*/**/inf*_cal_fail" and use
-        // the OPAE-API's support for arrays of sysobjects? The reason is that, at the time of this writing,
-        // the xfpga-plugin's sysobject implementation does not support arrays specifically when the glob contains
-        // a recursive wildcard "/**/". It's a strange and perhaps unnecessary limitation. Therefore, future work
-        // is to fix that and clean up the code below.
-        for (size_t i=0; i<MAX_NUM_MEM_CHANNELS;i++) {
-            std::stringstream mem_cal_glob;
-            mem_cal_glob << "*dfl*/**/inf" << i << "_cal_fail";
-            fpga::sysobject::ptr_t testobj = fpga::sysobject::get(token_device_,mem_cal_glob.str().c_str(),FPGA_OBJECT_GLOB);
-            if (testobj) {
-                // Error out if calibration has failed
-                if (testobj->read64(0)) { // Non-zero value (typically '1') means calibration has failed
-                    std::cout << "This sysfs entry reports that memory calibration has failed:" << mem_cal_glob.str().c_str() << std::endl;
-                    return -1;
-                }
-            }
-        }
-        
-        // Read HW details
-        uint64_t he_info = host_exe_->read64(HE_INFO0);
-        he_lpbk_api_ver_ = (he_info >> 16);
-        std::cout << "API version: " << uint32_t(he_lpbk_api_ver_) << std::endl;
-
-        // For atomics support, the version must not be zero and bit 24 must be 0.
-        he_lpbk_atomics_supported_ = (he_lpbk_api_ver_ != 0) &&
-                                     (0 == ((he_info >> 24) & 1));
-
-        // The maximum request length before API version 2 was 8.
-        he_lpbk_max_reqlen_ = (he_lpbk_api_ver_ < 2) ? HOSTEXE_CLS_8 : HOSTEXE_CLS_16;
-
-        if (0 == host_exe_->he_clock_mhz_) {
-            uint16_t freq = he_info;
-            if (freq) {
-                host_exe_->he_clock_mhz_ = freq;
-                std::cout << "AFU clock: "
-                          << host_exe_->he_clock_mhz_ << " MHz" << std::endl;
-            }
-            else {
-                host_exe_->he_clock_mhz_ = 350;
-                std::cout << "Frequency of AFU clock unknown. Assuming "
-                          << host_exe_->he_clock_mhz_ << " MHz." << std::endl;
-            }
-        }
-        else {
-            std::cout << "AFU clock from command line: "
-                      << host_exe_->he_clock_mhz_ << " MHz" << std::endl;
-        }
-
-        auto ret = parse_input_options();
-        if (ret != 0) {
-            std::cerr << "Failed to parse input options" << std::endl;
-            return ret;
-        }
-
-        // assert reset he-lpbk
-        he_lpbk_ctl_.value = 0;
-        d_afu->write32(HE_CTL, he_lpbk_ctl_.value);
-        usleep(1000);
-
-        // deassert reset he-lpbk
-        he_lpbk_ctl_.value = 0;
-        he_lpbk_ctl_.ResetL = 1;
-        d_afu->write32(HE_CTL, he_lpbk_ctl_.value);
-
-        /* Allocate Source Buffer
-        Write to CSR_SRC_ADDR */
-        std::cout << "Allocate SRC Buffer" << std::endl;
-        source_ = d_afu->allocate(LPBK1_BUFFER_ALLOCATION_SIZE);
-        host_exe_->logger_->debug("    VA 0x{0}  IOVA 0x{1:x}",
-                                  (void*)source_->c_type(), source_->io_address());
-        d_afu->write64(HE_SRC_ADDR, cacheline_aligned_addr(source_->io_address()));
+        // Initialize buffer values
         he_init_src_buffer(source_);
-
-        /* Allocate Destination Buffer
-            Write to CSR_DST_ADDR */
-        std::cout << "Allocate DST Buffer" << std::endl;
-        destination_ = d_afu->allocate(LPBK1_BUFFER_ALLOCATION_SIZE);
-        host_exe_->logger_->debug("    VA 0x{0}  IOVA 0x{1:x}",
-                                  (void*)destination_->c_type(), destination_->io_address());
-        d_afu->write64(HE_DST_ADDR, cacheline_aligned_addr(destination_->io_address()));
         std::fill_n(destination_->c_type(), LPBK1_BUFFER_SIZE, 0xBE);
 
-        /* Allocate DSM Buffer
-            Write to CSR_AFU_DSM_BASEL */
-        std::cout << "Allocate DSM Buffer" << std::endl;
-        dsm_ = d_afu->allocate(LPBK1_DSM_SIZE);
-        host_exe_->logger_->debug("    VA 0x{0}  IOVA 0x{1:x}",
-                                  (void*)dsm_->c_type(), dsm_->io_address());
-        d_afu->write32(HE_DSM_BASEL, cacheline_aligned_addr(dsm_->io_address()));
-        d_afu->write32(HE_DSM_BASEH, cacheline_aligned_addr(dsm_->io_address()) >> 32);
-        std::fill_n(dsm_->c_type(), LPBK1_DSM_SIZE, 0x0);
+        int test_status = run_single_test();
+        status |= test_status;
 
-        // Number of cache lines
-        d_afu->write64(HE_NUM_LINES, (LPBK1_BUFFER_SIZE / (1 * CL)) -1);
+        std::cout << "  " << af->first << ": "
+                  << (test_status ? "FAIL" : "PASS") << std::endl;
+      }
 
-        int status = 0;
-        if (host_exe_->he_test_all_)
-            status = run_all_tests();
-        else
-            status = run_single_test();
+      std::cout << std::endl
+                << "Testing atomic functions interspersed in continuous mode:"
+                << std::endl;
+      uint32_t trip = 0;
+      for (std::map<std::string, uint32_t>::const_reverse_iterator cls =
+               he_req_cls_len.rbegin();
+           cls != he_req_cls_len.rend(); ++cls) {
+        he_lpbk_cfg_.TestMode = HOST_EXEMODE_TRPUT;
 
-        return status;
+        if (cls->second > he_lpbk_max_reqlen_) break;
+        set_cfg_reqlen(cls->second);
+
+        he_lpbk_cfg_.AtomicFunc =
+            (trip & 1 ? HOSTEXE_ATOMIC_FADD_4 : HOSTEXE_ATOMIC_CAS_8);
+        host_exe_->he_continuousmode_ = true;
+        he_lpbk_cfg_.Continuous = 1;
+
+        int test_status = run_single_test();
+        status |= test_status;
+
+        std::cout << "  " << cls->first << " and "
+                  << (trip & 1 ? "fadd_4" : "cas_8") << ": "
+                  << (test_status ? "FAIL" : "PASS") << std::endl;
+
+        trip += 1;
+      }
+
+      he_lpbk_cfg_.AtomicFunc = HOSTEXE_ATOMIC_OFF;
     }
 
-protected:
-    he_cfg he_lpbk_cfg_;
-    he_ctl he_lpbk_ctl_;
-    host_exerciser *host_exe_;
-    shared_buffer::ptr_t source_;
-    shared_buffer::ptr_t destination_;
-    shared_buffer::ptr_t dsm_;
-    he_interrupt0 he_interrupt_;
-    token::ptr_t token_;
-    token::ptr_t token_device_;
-    hostexe_req_len he_lpbk_max_reqlen_;
-    uint8_t he_lpbk_api_ver_;
-    bool he_lpbk_atomics_supported_;
-    bool is_ase_sim_;
+    // Test throughput, varying read, write and size
+    std::cout << std::endl
+              << "Testing throughput (GB/s), varying payload size ("
+              << host_exe_->he_contmodetime_ << " seconds each):" << std::endl;
+    std::cout.setf(std::ios::fixed);
+    std::cout.precision(2);
+
+    // Get a pointer to the device status memory, needed to compute throughput
+    volatile he_dsm_status *dsm_status =
+        reinterpret_cast<he_dsm_status *>((uint8_t *)dsm_->c_type());
+
+    host_exe_->he_continuousmode_ = true;
+    he_lpbk_cfg_.Continuous = 1;
+    for (std::map<std::string, uint32_t>::const_iterator cls =
+             he_req_cls_len.begin();
+         cls != he_req_cls_len.end(); ++cls) {
+      if (cls->second > he_lpbk_max_reqlen_) break;
+      set_cfg_reqlen(cls->second);
+
+      he_lpbk_cfg_.TestMode = HOST_EXEMODE_READ;
+      int test_status = run_single_test();
+      status |= test_status;
+      std::cout << "  " << cls->first << " READ:  ";
+      if (test_status)
+        std::cout << "FAIL" << std::endl;
+      else {
+        std::cout << he_num_xfers_to_bw(dsm_num_reads(dsm_status),
+                                        dsm_num_ticks(dsm_status))
+                  << std::endl;
+      }
+
+      he_lpbk_cfg_.TestMode = HOST_EXEMODE_WRITE;
+      test_status = run_single_test();
+      status |= test_status;
+      std::cout << "  " << cls->first << " WRITE: ";
+      if (test_status)
+        std::cout << "FAIL" << std::endl;
+      else {
+        std::cout << he_num_xfers_to_bw(dsm_num_writes(dsm_status),
+                                        dsm_num_ticks(dsm_status))
+                  << std::endl;
+      }
+
+      he_lpbk_cfg_.TestMode = HOST_EXEMODE_TRPUT;
+      test_status = run_single_test();
+      status |= test_status;
+      std::cout << "  " << cls->first << " TRPUT: ";
+      if (test_status)
+        std::cout << "FAIL" << std::endl;
+      else {
+        std::cout << he_num_xfers_to_bw(
+                         dsm_num_reads(dsm_status) + dsm_num_writes(dsm_status),
+                         dsm_num_ticks(dsm_status))
+                  << std::endl;
+      }
+
+      std::cout << std::endl;
+    }
+
+    return status;
+  }
+
+  virtual int run(test_afu *afu, CLI::App *app) {
+    (void)app;
+
+    auto d_afu = dynamic_cast<host_exerciser *>(afu);
+    host_exe_ = dynamic_cast<host_exerciser *>(afu);
+
+    token_ = d_afu->get_token();
+    token_device_ = d_afu->get_token_device();
+
+    // Check if memory calibration has failed and error out before proceeding
+    // with the test. The dfl-emif driver creates sysfs entries to report the
+    // calibration status for each memory channel. sysobjects are the OPAE-API's
+    // abstraction for sysfs entries. However, at this time, these are only
+    // accessible through tokens that use the xfpga plugin and not the vfio
+    // plugin. Hence our use of the DEVICE token (token_device_). One
+    // non-ideality of the following implementation is the use of
+    // MAX_NUM_MEM_CHANNELS. We are essentially doing a brute-force query of
+    // sysfs entries since we don't know how many mem channels exist on the
+    // given platform. What about glob wildcards? Why not simply glob for
+    // "*dfl*/**/inf*_cal_fail" and use the OPAE-API's support for arrays of
+    // sysobjects? The reason is that, at the time of this writing, the
+    // xfpga-plugin's sysobject implementation does not support arrays
+    // specifically when the glob contains a recursive wildcard "/**/". It's a
+    // strange and perhaps unnecessary limitation. Therefore, future work is to
+    // fix that and clean up the code below.
+    for (size_t i = 0; i < MAX_NUM_MEM_CHANNELS; i++) {
+      std::stringstream mem_cal_glob;
+      mem_cal_glob << "*dfl*/**/inf" << i << "_cal_fail";
+      fpga::sysobject::ptr_t testobj = fpga::sysobject::get(
+          token_device_, mem_cal_glob.str().c_str(), FPGA_OBJECT_GLOB);
+      if (testobj) {
+        // Error out if calibration has failed
+        if (testobj->read64(0)) {  // Non-zero value (typically '1') means
+                                   // calibration has failed
+          std::cout
+              << "This sysfs entry reports that memory calibration has failed:"
+              << mem_cal_glob.str().c_str() << std::endl;
+          return -1;
+        }
+      }
+    }
+
+    // Read HW details
+    uint64_t he_info = host_exe_->read64(HE_INFO0);
+    he_lpbk_api_ver_ = (he_info >> 16);
+    std::cout << "API version: " << uint32_t(he_lpbk_api_ver_) << std::endl;
+
+    // For atomics support, the version must not be zero and bit 24 must be 0.
+    he_lpbk_atomics_supported_ =
+        (he_lpbk_api_ver_ != 0) && (0 == ((he_info >> 24) & 1));
+
+    // The maximum request length before API version 2 was 8.
+    he_lpbk_max_reqlen_ =
+        (he_lpbk_api_ver_ < 2) ? HOSTEXE_CLS_8 : HOSTEXE_CLS_16;
+
+    if (0 == host_exe_->he_clock_mhz_) {
+      uint16_t freq = he_info;
+      if (freq) {
+        host_exe_->he_clock_mhz_ = freq;
+        std::cout << "AFU clock: " << host_exe_->he_clock_mhz_ << " MHz"
+                  << std::endl;
+      } else {
+        host_exe_->he_clock_mhz_ = 350;
+        std::cout << "Frequency of AFU clock unknown. Assuming "
+                  << host_exe_->he_clock_mhz_ << " MHz." << std::endl;
+      }
+    } else {
+      std::cout << "AFU clock from command line: " << host_exe_->he_clock_mhz_
+                << " MHz" << std::endl;
+    }
+
+    auto ret = parse_input_options();
+    if (ret != 0) {
+      std::cerr << "Failed to parse input options" << std::endl;
+      return ret;
+    }
+
+    // assert reset he-lpbk
+    he_lpbk_ctl_.value = 0;
+    d_afu->write32(HE_CTL, he_lpbk_ctl_.value);
+    usleep(1000);
+
+    // deassert reset he-lpbk
+    he_lpbk_ctl_.value = 0;
+    he_lpbk_ctl_.ResetL = 1;
+    d_afu->write32(HE_CTL, he_lpbk_ctl_.value);
+
+    /* Allocate Source Buffer
+    Write to CSR_SRC_ADDR */
+    std::cout << "Allocate SRC Buffer" << std::endl;
+    source_ = d_afu->allocate(LPBK1_BUFFER_ALLOCATION_SIZE);
+    host_exe_->logger_->debug("    VA 0x{0}  IOVA 0x{1:x}",
+                              (void *)source_->c_type(), source_->io_address());
+    d_afu->write64(HE_SRC_ADDR, cacheline_aligned_addr(source_->io_address()));
+    he_init_src_buffer(source_);
+
+    /* Allocate Destination Buffer
+        Write to CSR_DST_ADDR */
+    std::cout << "Allocate DST Buffer" << std::endl;
+    destination_ = d_afu->allocate(LPBK1_BUFFER_ALLOCATION_SIZE);
+    host_exe_->logger_->debug("    VA 0x{0}  IOVA 0x{1:x}",
+                              (void *)destination_->c_type(),
+                              destination_->io_address());
+    d_afu->write64(HE_DST_ADDR,
+                   cacheline_aligned_addr(destination_->io_address()));
+    std::fill_n(destination_->c_type(), LPBK1_BUFFER_SIZE, 0xBE);
+
+    /* Allocate DSM Buffer
+        Write to CSR_AFU_DSM_BASEL */
+    std::cout << "Allocate DSM Buffer" << std::endl;
+    dsm_ = d_afu->allocate(LPBK1_DSM_SIZE);
+    host_exe_->logger_->debug("    VA 0x{0}  IOVA 0x{1:x}",
+                              (void *)dsm_->c_type(), dsm_->io_address());
+    d_afu->write32(HE_DSM_BASEL, cacheline_aligned_addr(dsm_->io_address()));
+    d_afu->write32(HE_DSM_BASEH,
+                   cacheline_aligned_addr(dsm_->io_address()) >> 32);
+    std::fill_n(dsm_->c_type(), LPBK1_DSM_SIZE, 0x0);
+
+    // Number of cache lines
+    d_afu->write64(HE_NUM_LINES, (LPBK1_BUFFER_SIZE / (1 * CL)) - 1);
+
+    int status = 0;
+    if (host_exe_->he_test_all_)
+      status = run_all_tests();
+    else
+      status = run_single_test();
+
+    return status;
+  }
+
+ protected:
+  he_cfg he_lpbk_cfg_;
+  he_ctl he_lpbk_ctl_;
+  host_exerciser *host_exe_;
+  shared_buffer::ptr_t source_;
+  shared_buffer::ptr_t destination_;
+  shared_buffer::ptr_t dsm_;
+  he_interrupt0 he_interrupt_;
+  token::ptr_t token_;
+  token::ptr_t token_device_;
+  hostexe_req_len he_lpbk_max_reqlen_;
+  uint8_t he_lpbk_api_ver_;
+  bool he_lpbk_atomics_supported_;
+  bool is_ase_sim_;
 };
 
-} // end of namespace host_exerciser
-
+}  // end of namespace host_exerciser

--- a/samples/host_exerciser/host_exerciser_cmd.h
+++ b/samples/host_exerciser/host_exerciser_cmd.h
@@ -763,15 +763,16 @@ public:
           // Ask for a sysobject with this glob string
           fpga::sysobject::ptr_t testobj = fpga::sysobject::get(
               token_device_, mem_cal_glob.str().c_str(), FPGA_OBJECT_GLOB);
-          if (testobj) { // if !=null, the sysfs entry was found
-            // Error out if calibration has failed
-            if (testobj->read64(0)) {  // Non-zero value (typically '1') means
-                                       // calibration has failed
-              std::cout
-                  << "This sysfs entry reports that memory calibration has failed:"
-                  << mem_cal_glob.str().c_str() << std::endl;
-              return -1;
-            }
+
+          // if test obj !=null, the sysfs entry was found.
+          // Read the calibration status from the sysfs entry.
+          // A non-zero value (typically '1') means
+          // calibration has failed --> we error out.
+          if (testobj && testobj->read64(0)) { 
+            std::cout
+                << "This sysfs entry reports that memory calibration has failed:"
+                << mem_cal_glob.str().c_str() << std::endl;
+            return -1;
           }
         }
 

--- a/samples/host_exerciser/host_exerciser_cmd.h
+++ b/samples/host_exerciser/host_exerciser_cmd.h
@@ -757,10 +757,13 @@ public:
         // fix that and clean up the code below.
         for (size_t i = 0; i < MAX_NUM_MEM_CHANNELS; i++) {
           std::stringstream mem_cal_glob;
+          // Construct the glob string to search for the cal_fail sysfs entry
+          // for the i'th mem channel
           mem_cal_glob << "*dfl*/**/inf" << i << "_cal_fail";
+          // Ask for a sysobject with this glob string
           fpga::sysobject::ptr_t testobj = fpga::sysobject::get(
               token_device_, mem_cal_glob.str().c_str(), FPGA_OBJECT_GLOB);
-          if (testobj) {
+          if (testobj) { // if !=null, the sysfs entry was found
             // Error out if calibration has failed
             if (testobj->read64(0)) {  // Non-zero value (typically '1') means
                                        // calibration has failed


### PR DESCRIPTION
### Description
This change addresses [this ](https://hsdes.intel.com/appstore/article/#/14019997425) bug/case.

The bug is that the host_exerciser utility (which pushes traffic between the host and FPGA-attached DDR) would fail non-gracefully if the DDR calibration had failed. Fortunately the calibration status is reported by the dfl-emif driver via sysfs entries (one per mem channel). This change simply errors-out gracefully, with a useful error message, after reading the sysfs entries.

The host_exerciser utility is built on top of the afu_test framework. The corresponding AFU is exposed as a PCIe Virtual Function (VF). As described in the [docs](https://ofs.github.io/ofs-2023.2/hw/n6001/user_guides/ug_qs_ofs_n6001/ug_qs_ofs_n6001/#447-host-exercisor-modules), the user must first bind the VF endpoint to the vfio-pci driver. This seems to also result in OPAE using the _opae-v_ (VFIO-specific) plugin rather than the _xfpga_ plugin. The _opae-v_ plugin only exposes a subset of the OPAE-API and notably omits functions related to sysobjects (which are used to access sysfs entries). Therefore the afu_test framework has also been updated to grab a handle to the FPGA_DEVICE (i.e. the FIM) so that we can access sysobjects.

I've noted in the code comments that the change is a bit kludgy, owing to the fact that we don't know how many mem channels are present on the given board and therefore don't know how many sysfs entries we need to poll. While xfpga's sysobject implementation supports wildcarded searches for sysfs entries (via glob) and can return _arrays_ of such objects, it oddly, specifically, disables this behaviour if the glob string uses a recursive wildcard ("/**/"). I think such a wildcard is necessary since we shouldn't assume a fixed sysfs folder hierarchy. So future work is to remove this, likely, unnecessary restriction in the sysobject implementation. I just don't have time for this given the release deadline is next week.

### Collateral (docs, reports, design examples, case IDs):

### Tests added:

### Tests run:
- Manually tested on N6001. I don't know how to force a calibration failure in the hardware so I tested by simply flipping the polarity of the sysfs-read() result and ensuring the program fails gracefully.