### PR TITLE
opae.io: Fix error handling when binding the vfio-pci driver fails

### DIFF
--- a/binaries/opae.io/opae/io/utils.py
+++ b/binaries/opae.io/opae/io/utils.py
@@ -145,6 +145,10 @@ def vfio_init(pci_addr, new_owner='', force=False, **kwargs):
     msg = '(0x{:04x},0x{:04x}) at {}'.format(
         int(vid_did[0], 16), int(vid_did[1], 16), pci_addr)
 
+    if not iommu_enabled():
+        LOG.error("Binding to vfio-pci will fail because IOMMU is disabled.")
+        raise SystemExit(os.EX_NOTFOUND)
+
     if driver and driver != 'vfio-pci':
         dev_dict = get_dev_dict(JSON_FILE)
         dev_dict[pci_addr] = driver
@@ -198,9 +202,6 @@ def vfio_init(pci_addr, new_owner='', force=False, **kwargs):
             return
 
     time.sleep(0.50)
-
-    if not iommu_enabled():
-        LOG.info("IOMMU is disabled. Binding failed.")
 
     iommu_group = os.path.join('/sys/bus/pci/devices',
                                pci_addr,


### PR DESCRIPTION
The 'opae.io init' command can fail to bind the vfio-pci driver when the IOMMU is disabled, leaving the system seemingly unable to bind another driver. The fix is to check if the IOMMU is enabled before even attempting to bind the vfio-pci driver.

