### PR TITLE
fpgasupdate:set the progress bar's maximum value to 100% if it exceeds

### DIFF
--- a/python/opae.admin/opae/admin/utils/progress.py
+++ b/python/opae.admin/opae/admin/utils/progress.py
@@ -121,6 +121,8 @@ class progress(loggable):
             function, otherwise, None.
         """
         percent = int(pct*100)
+        if percent > 100:
+            percent = 100
         num_bars = int(pct*self._total_bars)
         bars = self.BAR*num_bars
         spaces = ' '*(self._total_bars - num_bars)


### PR DESCRIPTION
 fpgasupdate progress bars display 200% or 300% for root key hash and cancel key programming, which exceeds 100%.
 set the progress bar maximum to 100% if the computations exceed 100.

