### PR TITLE
(Cherry-pick) hssi: set sbd properties to enumerate fpga device and set sbdf  prope…

### DIFF
--- a/libraries/afu-test/afu_test.h
+++ b/libraries/afu-test/afu_test.h
@@ -204,13 +204,12 @@ public:
     // This is to allow access to OPAE-API functions that are only supported
     // through the xfpga plugin (i.e accessing sysfs entries)
     // In contrast, the ACCELERATOR token may be underlied by the vfio plugin.
-    
+    // Set PCIe segment, bus, and device properties to enumerate FPGA DEVICE (FME)
     if (!pci_addr_.empty()) {
       auto p = pcie_address::parse(pci_addr_.c_str());
       filter->segment = p.fields.domain;
       filter->bus = p.fields.bus;
       filter->device = p.fields.device;
-      filter->function = p.fields.function;
     }
 
     filter->type = FPGA_DEVICE;
@@ -242,7 +241,12 @@ public:
 
     // The following code attempts to get a token + handle for the AFU 
     // (ACCELERATOR device) matching the given command's afu_id.
-    // We reuse the PCIe SBDF addressing from above.
+    // Set PCIe segment, bus, device, and functionproperties to enumerate FPGA ACCELERATOR 
+    if (!pci_addr_.empty()) {
+        auto p = pcie_address::parse(pci_addr_.c_str());
+        filter->function = p.fields.function;
+    }
+
     auto app_afu_id = afu_id ? afu_id : afu_id_.c_str();
     filter->type = FPGA_ACCELERATOR;
     try {


### PR DESCRIPTION
…rties to enumerate afu (#3103)

Set PCIe segment, bus, and device properties to enumerate FPGA DEVICE (FME)
 Set PCIe segment, bus, device, and function properties to enumerate FPGA ACCELERATOR

 hssi hssi_10g works fine,
 hssi—pci-address b1:00.6 hssi_10g fails if the user provides pci-address cmd args due to PR change. #3094

 Set the HSSI/VF PCIe segment, bus, device, and function attributes to try to enumerate FPGA DEVICE (FME) triggers failure, to enumerate FPGA DEVICE set seegment, bus, device attributes to OPAE filter.
