### PR TITLE
(Cherry-pick) host_exerciser:support no FPGA mgmt PF instances (#3108)

### DIFF
--- a/libraries/afu-test/afu_test.h
+++ b/libraries/afu-test/afu_test.h
@@ -172,6 +172,7 @@ public:
   , shared_(false)
   , timeout_msec_(60000)
   , handle_(nullptr)
+  , handle_device_(nullptr)
   , current_command_(nullptr)
   {
     if (!afu_id_.empty())
@@ -196,8 +197,52 @@ public:
     return fpga::properties::get(handle_);
   }
 
+  bool enum_fpga_device()
+  {
+    auto filter = fpga::properties::get(); // Get an empty properties object
+
+                                             // The following code attempts to get a token+handle for the DEVICE.
+    // This is to allow access to OPAE-API functions that are only supported
+    // through the xfpga plugin (i.e accessing sysfs entries)
+    // In contrast, the ACCELERATOR token may be underlied by the vfio plugin.
+    // Set PCIe segment, bus, and device properties to enumerate FPGA DEVICE (FME)
+    if (!pci_addr_.empty()) {
+        auto p = pcie_address::parse(pci_addr_.c_str());
+        filter->segment = p.fields.domain;
+        filter->bus = p.fields.bus;
+        filter->device = p.fields.device;
+    }
+
+    filter->type = FPGA_DEVICE;
+    auto tokens = fpga::token::enumerate({ filter });
+
+    // Error out if the # of tokens != 1
+    if (tokens.size() < 1) {
+        logger_->info("no FPGA DEVICE found");
+        return false;
+    }
+
+    if (tokens.size() > 1) {
+        logger_->info("more than one FPGA DEVICE found ");
+        return false;
+    }
+
+    int flags = shared_ ? FPGA_OPEN_SHARED : 0;
+    // Open a handle to the resource
+    try {
+        handle_device_ = fpga::handle::open(tokens[0], flags);
+    }
+    catch (fpga::no_access& err) {
+        std::cerr << err.what() << "\n";
+        return false;
+    }
+    return true;
+  }
+
   int open_handle(const char *afu_id) {
-    
+
+    enum_fpga_device();
+
     auto filter = fpga::properties::get(); // Get an empty properties object
 
     // The following code attempts to get a token+handle for the DEVICE.
@@ -210,41 +255,7 @@ public:
       filter->segment = p.fields.domain;
       filter->bus = p.fields.bus;
       filter->device = p.fields.device;
-    }
-
-    filter->type = FPGA_DEVICE;
-    auto tokens = fpga::token::enumerate({filter});
-
-    // Error out if the # of tokens != 1
-    if (tokens.size() < 1) {
-      if (pci_addr_.empty()) {
-        logger_->error("no DEVICE found");
-      } else {
-        logger_->error("no accelerator found at PCIe address {1}",
-            pci_addr_);
-      }
-      return exit_codes::not_found;
-    }    
-
-    if (tokens.size() > 1) {
-      std::cerr << "more than one DEVICE found matching filter\n";
-    }
-    int flags = shared_ ? FPGA_OPEN_SHARED : 0;
-    
-    // Open a handle to the resource
-    try {
-      handle_device_ = fpga::handle::open(tokens[0], flags);
-    } catch (fpga::no_access &err) {
-      std::cerr << err.what() << "\n";
-      return exit_codes::no_access;
-    }
-
-    // The following code attempts to get a token + handle for the AFU 
-    // (ACCELERATOR device) matching the given command's afu_id.
-    // Set PCIe segment, bus, device, and functionproperties to enumerate FPGA ACCELERATOR 
-    if (!pci_addr_.empty()) {
-        auto p = pcie_address::parse(pci_addr_.c_str());
-        filter->function = p.fields.function;
+      filter->function = p.fields.function;
     }
 
     auto app_afu_id = afu_id ? afu_id : afu_id_.c_str();
@@ -255,7 +266,7 @@ public:
       return error;
     }
 
-    tokens = fpga::token::enumerate({filter});
+    auto tokens = fpga::token::enumerate({filter});
     if (tokens.size() < 1) {
       if (pci_addr_.empty()) {
         logger_->error("no accelerator found with id: {0}", app_afu_id);
@@ -266,10 +277,7 @@ public:
       return exit_codes::not_found;
     }
 
-    if (tokens.size() > 1) {
-      std::cerr << "more than one accelerator found matching filter\n";
-    }
-    
+    int flags = shared_ ? FPGA_OPEN_SHARED : 0;
     try {
       handle_ = fpga::handle::open(tokens[0], flags);
     } catch (fpga::no_access &err) {

--- a/samples/host_exerciser/host_exerciser.h
+++ b/samples/host_exerciser/host_exerciser.h
@@ -575,7 +575,9 @@ public:
 
   token::ptr_t get_token_device()
   {
-    return handle_device_->get_token();
+    if (handle_device_)
+        return handle_device_->get_token();
+    return nullptr;
   }
 
   bool option_passed(std::string option_str)


### PR DESCRIPTION
* host_exerciser:support no FPGA mgmt PF instances

Issue: The host exerciser fails to execute on Devkits if it does not support FPGA management PF. The host exerciser enumerates FME and quits the program if the bitstream does not support it.

The I series-DK and F series-DK have multiple host exerciser AFUs on separate PCIe bus, device functions.

fix: If the bitstream does not support FME, perform the host exerciser tests and print message.

host_exerciser --pci-address 0000:03:00.2 lpbk
host_exerciser --pci-address 0000:04:00.2 lpbk

opae.io ls
[0000:03:00.0] (0x8086:0xbcce 0x8086:0x1771) Intel Acceleration Development Platform N6001 (Driver: dfl-pci) [0000:04:00.7] (0x8086:0xbccf 0x8086:0x1771) Intel Acceleration Development Platform N6001 (Driver: None) [0000:04:00.5] (0x8086:0xbccf 0x8086:0x1771) Intel Acceleration Development Platform N6001 (Driver: vfio-pci) [0000:03:00.7] (0x8086:0xbccf 0x8086:0x1771) Intel Acceleration Development Platform N6001 (Driver: vfio-pci) [0000:04:00.3] (0x8086:0xbcce 0x8086:0x1771) Intel Acceleration Development Platform N6001 (Driver: dfl-pci) [0000:03:00.5] (0x8086:0xbccf 0x8086:0x1771) Intel Acceleration Development Platform N6001 (Driver: vfio-pci) [0000:04:00.1] (0x8086:0xbcce 0x8086:0x1771) Intel Acceleration Development Platform N6001 (Driver: dfl-pci) [0000:03:00.3] (0x8086:0xbcce 0x8086:0x1771) Intel Acceleration Development Platform N6001 (Driver: dfl-pci) [0000:03:00.1] (0x8086:0xbcce 0x8086:0x1771) Intel Acceleration Development Platform N6001 (Driver: dfl-pci) [0000:04:00.6] (0x8086:0xbccf 0x8086:0x1771) Intel Acceleration Development Platform N6001 (Driver: None) [0000:04:00.4] (0x8086:0xbcce 0x8086:0x1771) Intel Acceleration Development Platform N6001 (Driver: dfl-pci) [0000:03:00.6] (0x8086:0xbccf 0x8086:0x1771) Intel Acceleration Development Platform N6001 (Driver: vfio-pci) [0000:04:00.2] (0x8086:0xbcce 0x8086:0x1771) Intel Acceleration Development Platform N6001 (Driver: vfio-pci) [0000:03:00.4] (0x8086:0xbcce 0x8086:0x1771) Intel Acceleration Development Platform N6001 (Driver: dfl-pci) [0000:04:00.0] (0x8086:0xbcce 0x8086:0x1771) Intel Acceleration Development Platform N6001 (Driver: dfl-pci) [0000:03:00.2] (0x8086:0xbcce 0x8086:0x1771) Intel Acceleration Development Platform N6001 (Driver: vfio-pci)

--------
