### PR TITLE
[Update] - Add support to host_exerciser for varying HE LB data bus widths

### DIFF
--- a/samples/host_exerciser/host_exerciser.h
+++ b/samples/host_exerciser/host_exerciser.h
@@ -37,10 +37,8 @@ using opae::fpga::types::token;
 
 static const uint64_t HELPBK_TEST_TIMEOUT = 30000;
 static const uint64_t HELPBK_TEST_SLEEP_INVL = 100;
-static const uint64_t CL = 64;
 static const uint64_t KB = 1024;
 static const uint64_t MB = KB * 1024;
-static const uint64_t LOG2_CL = 6;
 static const size_t LPBK1_DSM_SIZE = 2 * KB;
 static const size_t LPBK1_BUFFER_SIZE = 64 * KB;
 static const size_t LPBK1_BUFFER_ALLOCATION_SIZE = 64 * KB;


### PR DESCRIPTION
### Description
New API version exported by HW includes a CSR with the bus width.

### Collateral (docs, reports, design examples, case IDs):

- [ ] Document Update Required? (Specify FIM/AFU/Scripts)

### Tests added:


### Tests run:
HE LB