### PR TITLE
platform: add a mechanism for AFU's to set platform macros

### DIFF
--- a/platforms/platmgr/tools/afu_platform_config.py
+++ b/platforms/platmgr/tools/afu_platform_config.py
@@ -284,6 +284,13 @@ legal_afu_ifc_update_classes = {
 def injectAfuIfcChanges(args, afu_ifc_db, afu_ifc_req):
     fname = afu_ifc_req['file_path']
 
+    # Allow an AFU's JSON configuration to create macros
+    if ('define' in afu_ifc_req):
+        if ('define' in afu_ifc_db):
+            afu_ifc_db['define'] += afu_ifc_req['define']
+        else:
+            afu_ifc_db['define'] = afu_ifc_req['define']
+
     if ('module-ports' not in afu_ifc_req):
         return
     if (not isinstance(afu_ifc_req['module-ports'], list)):


### PR DESCRIPTION
Due to the order that SystemVerilog header files are processed, setting a macro in an AFU's sources file may not affect the FIM's afu_main(). Add support for writing macros to the PIM interface header file that afu_main() includes explicity.
