### PR TITLE
host_exerciser: fix buffer comparison in interrupt test mode

### DIFF
--- a/samples/host_exerciser/host_exerciser_cmd.h
+++ b/samples/host_exerciser/host_exerciser_cmd.h
@@ -198,8 +198,6 @@ public:
     {
         try {
             host_exe_->interrupt_wait(ev, 10000);
-            if (he_lpbk_cfg_.TestMode == HOST_EXEMODE_LPBK1)
-                host_exe_->compare(source_, destination_);
         }
         catch (std::exception &ex) {
             std::cout << "Exception: " << ex.what() << std::endl;


### PR DESCRIPTION
Buffer comparison varies by FPGA configuration. Stop calling direct memory comparison in interrupt test mode. The caller of he_interrupt() already does the proper test.

### Tests run:
Gen5x16 FPGA