### PR TITLE
[Fix]- Ubuntu 24.04 debian package build issue

### DIFF
--- a/packaging/opae/deb/opae-devel.install
+++ b/packaging/opae/deb/opae-devel.install
@@ -66,6 +66,6 @@ usr/lib/python3/dist-packages/hssi_ethernet*
 usr/lib/python3/dist-packages/pacsign*
 usr/lib/python3/dist-packages/packager*
 usr/lib/python3/dist-packages/libvfio*
-usr/lib/python3/dist-packages/opae.fpga*
+usr/lib/python3/dist-packages/opae_fpga*
 usr/lib/python3/dist-packages/opae/fpga*
 usr/lib/python3/dist-packages/platmgr*

--- a/packaging/opae/deb/opae-extra-tools.install
+++ b/packaging/opae/deb/opae-extra-tools.install
@@ -26,10 +26,10 @@ usr/bin/hssi
 usr/bin/opae.io
 usr/bin/mem_tg
 usr/bin/ofs.uio
-usr/lib/python3/dist-packages/opae.diag*
+usr/lib/python3/dist-packages/opae_diag*
 usr/lib/python3/dist-packages/opae/diag*
-usr/lib/python3/dist-packages/opae.io*
+usr/lib/python3/dist-packages/opae_io*
 usr/lib/python3/dist-packages/opae/io*
 usr/lib/python3/dist-packages/pyopaeuio*
-usr/lib/python3/dist-packages/ofs.uio*
+usr/lib/python3/dist-packages/ofs_uio*
 usr/lib/python3/dist-packages/uio*

--- a/packaging/opae/deb/opae.install
+++ b/packaging/opae/deb/opae.install
@@ -34,7 +34,7 @@ usr/bin/fpgainfo
 usr/bin/fpgasupdate
 usr/bin/rsu
 usr/bin/pci_device
-usr/lib/python3/dist-packages/opae.admin*
+usr/lib/python3/dist-packages/opae_admin*
 usr/lib/python3/dist-packages/opae/admin*
 etc/sysconfig/fpgad.conf
 usr/lib/systemd/system/fpgad.service


### PR DESCRIPTION
Deb package: Changed dots to underscores in debian install files

Take a look at PEP 427 [https://peps.python.org/pep-0427/].which specifies that dots in the project name are normalized to underscores in the wheel filename for compatibility and to avoid issues with filesystems and tooling.


