### PR TITLE
[Fix] userclk: increase the reset delay

### DIFF
--- a/libraries/plugins/xfpga/usrclk/fpga_user_clk.c
+++ b/libraries/plugins/xfpga/usrclk/fpga_user_clk.c
@@ -47,7 +47,7 @@
 #define IOPLL_MEASURE_LOW             0
 #define IOPLL_MEASURE_HIGH            1
 #define IOPLL_MEASURE_DELAY_US        8000
-#define IOPLL_RESET_DELAY_US          1000
+#define IOPLL_RESET_DELAY_US          10000
 
  // DFHv0
 struct dfh {


### PR DESCRIPTION
Agilex 5 user clock reset was unreliable with the previous timeout.
